### PR TITLE
API improvements

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManager.java
@@ -13,9 +13,11 @@ import org.ethereum.beacon.discovery.schema.NodeRecord;
  */
 public interface DiscoveryManager {
 
-  void start();
+  CompletableFuture<Void> start();
 
   void stop();
+
+  NodeRecord getLocalNodeRecord();
 
   /**
    * Initiates FINDNODE with node `nodeRecord`

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerBuilder.java
@@ -1,0 +1,91 @@
+package org.ethereum.beacon.discovery;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Arrays.asList;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.database.Database;
+import org.ethereum.beacon.discovery.scheduler.Schedulers;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.storage.NodeBucketStorage;
+import org.ethereum.beacon.discovery.storage.NodeBucketStorageImpl;
+import org.ethereum.beacon.discovery.storage.NodeSerializerFactory;
+import org.ethereum.beacon.discovery.storage.NodeTableStorage;
+import org.ethereum.beacon.discovery.storage.NodeTableStorageFactory;
+import org.ethereum.beacon.discovery.storage.NodeTableStorageFactoryImpl;
+
+public class DiscoveryManagerBuilder {
+  private static final AtomicInteger COUNTER = new AtomicInteger();
+  private List<NodeRecord> bootnodes = Collections.emptyList();
+  private NodeRecord localNodeRecord;
+  private Bytes privateKey;
+  private final NodeRecordFactory nodeRecordFactory = NodeRecordFactory.DEFAULT;
+  private Database database;
+  private Schedulers schedulers;
+
+  public DiscoveryManagerBuilder localNodeRecord(final NodeRecord localNodeRecord) {
+    this.localNodeRecord = localNodeRecord;
+    return this;
+  }
+
+  public DiscoveryManagerBuilder privateKey(final Bytes privateKey) {
+    this.privateKey = privateKey;
+    return this;
+  }
+
+  public DiscoveryManagerBuilder bootnodes(final String... enrs) {
+    bootnodes =
+        Stream.of(enrs)
+            .map(enr -> enr.startsWith("enr:") ? enr.substring("enr:".length()) : enr)
+            .map(nodeRecordFactory::fromBase64)
+            .collect(Collectors.toList());
+    return this;
+  }
+
+  public DiscoveryManagerBuilder bootnodes(final NodeRecord... records) {
+    bootnodes = asList(records);
+    return this;
+  }
+
+  public DiscoveryManagerBuilder database(final Database database) {
+    this.database = database;
+    return this;
+  }
+
+  public DiscoveryManagerBuilder schedulers(final Schedulers schedulers) {
+    this.schedulers = schedulers;
+    return this;
+  }
+
+  public DiscoveryManager build() {
+    checkNotNull(localNodeRecord, "Missing local node record");
+    checkNotNull(privateKey, "Missing private key");
+
+    if (database == null) {
+      database = Database.inMemoryDB();
+    }
+    final NodeTableStorageFactory nodeTableStorageFactory = new NodeTableStorageFactoryImpl();
+    final NodeSerializerFactory serializerFactory = new NodeSerializerFactory(nodeRecordFactory);
+    final NodeTableStorage nodeTable =
+        nodeTableStorageFactory.createTable(
+            database, serializerFactory, oldSeq -> localNodeRecord, () -> bootnodes);
+    if (schedulers == null) {
+      schedulers = Schedulers.createDefault();
+    }
+    final NodeBucketStorage nodeBucketStorage =
+        new NodeBucketStorageImpl(database, serializerFactory, localNodeRecord);
+    return new DiscoveryManagerImpl(
+        nodeTable.get(),
+        nodeBucketStorage,
+        localNodeRecord,
+        privateKey,
+        nodeRecordFactory,
+        schedulers.newSingleThreadDaemon("client-" + COUNTER.incrementAndGet()));
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerBuilder.java
@@ -1,3 +1,6 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.ethereum.beacon.discovery;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -52,7 +52,7 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
   private final Pipeline incomingPipeline = new PipelineImpl();
   private final Pipeline outgoingPipeline = new PipelineImpl();
   private final NodeRecord homeNodeRecord;
-  private DiscoveryClient discoveryClient;
+  private volatile DiscoveryClient discoveryClient;
 
   public DiscoveryManagerImpl(
       NodeTable nodeTable,
@@ -110,7 +110,10 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
 
   @Override
   public void stop() {
-    discoveryClient.stop();
+    final DiscoveryClient client = this.discoveryClient;
+    if (client != null) {
+      client.stop();
+    }
     discoveryServer.stop();
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/network/DiscoveryServer.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/DiscoveryServer.java
@@ -4,13 +4,13 @@
 
 package org.ethereum.beacon.discovery.network;
 
+import java.util.concurrent.CompletableFuture;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.reactivestreams.Publisher;
 
 /** Discovery server which listens to incoming messages according to setup */
 public interface DiscoveryServer {
-  void start(Scheduler scheduler);
+  CompletableFuture<?> start();
 
   void stop();
 

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
@@ -11,7 +11,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -23,9 +22,7 @@ import reactor.core.publisher.Flux;
 
 /** Netty discovery UDP client */
 public class NettyDiscoveryClientImpl implements DiscoveryClient {
-  private static final int STOPPING_TIMEOUT = 10000;
   private static final Logger logger = LogManager.getLogger(NettyDiscoveryClientImpl.class);
-  private AtomicBoolean listen = new AtomicBoolean(false);
   private NioDatagramChannel channel;
 
   /**
@@ -45,25 +42,10 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
                     networkPacket.getNodeRecord(),
                     networkPacket.getReplyDestination()));
     logger.info("UDP discovery client started");
-    listen.set(true);
   }
 
   @Override
-  public void stop() {
-    if (listen.get()) {
-      logger.info("Stopping discovery client");
-      listen.set(false);
-      if (channel != null) {
-        try {
-          channel.close().await(STOPPING_TIMEOUT);
-        } catch (InterruptedException ex) {
-          logger.error("Failed to stop discovery client", ex);
-        }
-      }
-    } else {
-      logger.warn("An attempt to stop already stopping/stopped discovery client");
-    }
-  }
+  public void stop() {}
 
   @Override
   public void send(

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServer.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServer.java
@@ -6,11 +6,10 @@ package org.ethereum.beacon.discovery.network;
 
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 /** Netty-specific extension of {@link DiscoveryServer}. Made to reuse server channel for client. */
 public interface NettyDiscoveryServer extends DiscoveryServer {
 
-  /** Reuse Netty server channel with client, so you are able to send packets from the same port */
-  CompletableFuture<Void> useDatagramChannel(Consumer<NioDatagramChannel> consumer);
+  @Override
+  CompletableFuture<NioDatagramChannel> start();
 }

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -97,7 +97,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
                     Thread.sleep(RECREATION_TIMEOUT);
                     startServer(group);
                   });
-          future.complete((NioDatagramChannel)this.channel);
+          future.complete((NioDatagramChannel) this.channel);
         });
     return future;
   }

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -86,7 +86,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
                   closeFuture -> {
                     if (!listen.get()) {
                       logger.info("Shutting down discovery server");
-                      group.shutdownGracefully().sync();
+                      group.shutdownGracefully();
                       return;
                     }
                     logger.error(
@@ -113,7 +113,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
       logger.info("Stopping discovery server");
       if (channel != null) {
         try {
-          channel.close().await(STOPPING_TIMEOUT);
+          channel.close().sync();
         } catch (InterruptedException ex) {
           logger.error("Failed to stop discovery server", ex);
         }

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery.network;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
@@ -13,16 +14,12 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.ReplayProcessor;
@@ -35,10 +32,8 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
   private final FluxSink<Envelope> incomingSink = incomingPackets.sink();
   private final Integer udpListenPort;
   private final String udpListenHost;
-  private AtomicBoolean listen = new AtomicBoolean(true);
+  private AtomicBoolean listen = new AtomicBoolean(false);
   private Channel channel;
-  private NioDatagramChannel datagramChannel;
-  private Set<Consumer<NioDatagramChannel>> datagramChannelUsageQueue = new HashSet<>();
 
   public NettyDiscoveryServerImpl(Bytes udpListenHost, Integer udpListenPort) { // bytes4
     try {
@@ -50,53 +45,61 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
   }
 
   @Override
-  public void start(Scheduler scheduler) {
+  public CompletableFuture<NioDatagramChannel> start() {
     logger.info(String.format("Starting discovery server on UDP port %s", udpListenPort));
-    scheduler.execute(this::serverLoop);
+    if (!listen.compareAndSet(false, true)) {
+      return CompletableFuture.failedFuture(
+          new IllegalStateException("Attempted to start an already started server"));
+    }
+    NioEventLoopGroup group = new NioEventLoopGroup(1);
+    return startServer(group);
   }
 
-  private void serverLoop() {
-    NioEventLoopGroup group = new NioEventLoopGroup(1);
-    try {
-      while (listen.get()) {
-        Bootstrap b = new Bootstrap();
-        b.group(group)
-            .channel(NioDatagramChannel.class)
-            .handler(
-                new ChannelInitializer<NioDatagramChannel>() {
-                  @Override
-                  public void initChannel(NioDatagramChannel ch) {
-                    ch.pipeline()
-                        .addFirst(new LoggingHandler(LogLevel.TRACE))
-                        .addLast(new DatagramToEnvelope())
-                        .addLast(new IncomingMessageSink(incomingSink));
-                    synchronized (NettyDiscoveryServerImpl.class) {
-                      datagramChannel = ch;
-                      datagramChannelUsageQueue.forEach(
-                          nioDatagramChannelConsumer -> nioDatagramChannelConsumer.accept(ch));
+  private CompletableFuture<NioDatagramChannel> startServer(final NioEventLoopGroup group) {
+    CompletableFuture<NioDatagramChannel> future = new CompletableFuture<>();
+    Bootstrap b = new Bootstrap();
+    b.group(group)
+        .channel(NioDatagramChannel.class)
+        .handler(
+            new ChannelInitializer<NioDatagramChannel>() {
+              @Override
+              public void initChannel(NioDatagramChannel ch) {
+                ch.pipeline()
+                    .addFirst(new LoggingHandler(LogLevel.TRACE))
+                    .addLast(new DatagramToEnvelope())
+                    .addLast(new IncomingMessageSink(incomingSink));
+              }
+            });
+
+    final ChannelFuture bindFuture = b.bind(udpListenHost, udpListenPort);
+    bindFuture.addListener(
+        result -> {
+          if (!result.isSuccess()) {
+            future.completeExceptionally(result.cause());
+            return;
+          }
+
+          this.channel = bindFuture.channel();
+          channel
+              .closeFuture()
+              .addListener(
+                  closeFuture -> {
+                    if (!listen.get()) {
+                      logger.info("Shutting down discovery server");
+                      group.shutdownGracefully().sync();
+                      return;
                     }
-                  }
-                });
-
-        channel = b.bind(udpListenHost, udpListenPort).sync().channel();
-        channel.closeFuture().sync();
-
-        if (!listen.get()) {
-          logger.info("Shutting down discovery server");
-          break;
-        }
-        logger.error("Discovery server closed. Trying to restore after %s seconds delay");
-        Thread.sleep(RECREATION_TIMEOUT);
-      }
-    } catch (Exception e) {
-      logger.error("Can't start discovery server", e);
-    } finally {
-      try {
-        group.shutdownGracefully().sync();
-      } catch (Exception ex) {
-        logger.error("Failed to shutdown discovery sever thread group", ex);
-      }
-    }
+                    logger.error(
+                        "Discovery server closed. Trying to restore after "
+                            + RECREATION_TIMEOUT
+                            + " milliseconds delay",
+                        closeFuture.cause());
+                    Thread.sleep(RECREATION_TIMEOUT);
+                    startServer(group);
+                  });
+          future.complete((NioDatagramChannel)this.channel);
+        });
+    return future;
   }
 
   @Override
@@ -104,30 +107,10 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
     return incomingPackets;
   }
 
-  /** Reuse Netty server channel with client, so you are able to send packets from the same port */
-  @Override
-  public synchronized CompletableFuture<Void> useDatagramChannel(
-      Consumer<NioDatagramChannel> consumer) {
-    CompletableFuture<Void> usage = new CompletableFuture<>();
-    if (datagramChannel != null) {
-      consumer.accept(datagramChannel);
-      usage.complete(null);
-    } else {
-      datagramChannelUsageQueue.add(
-          nioDatagramChannel -> {
-            consumer.accept(nioDatagramChannel);
-            usage.complete(null);
-          });
-    }
-
-    return usage;
-  }
-
   @Override
   public void stop() {
-    if (listen.get()) {
+    if (listen.compareAndSet(true, false)) {
       logger.info("Stopping discovery server");
-      listen.set(false);
       if (channel != null) {
         try {
           channel.close().await(STOPPING_TIMEOUT);

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -25,9 +25,8 @@ import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.ReplayProcessor;
 
 public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
-  private static final int RECREATION_TIMEOUT = 5000;
-  private static final int STOPPING_TIMEOUT = 10000;
   private static final Logger logger = LogManager.getLogger(NettyDiscoveryServerImpl.class);
+  private static final int RECREATION_TIMEOUT = 5000;
   private final ReplayProcessor<Envelope> incomingPackets = ReplayProcessor.cacheLast();
   private final FluxSink<Envelope> incomingSink = incomingPackets.sink();
   private final Integer udpListenPort;

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -74,7 +74,6 @@ public class DiscoveryInteropTest {
             nodeRecord1,
             nodePair1.getValue0(),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("server-1"),
             Schedulers.createDefault().newSingleThreadDaemon("tasks-1"));
 
     // 3) Expect standard 1 => 2 dialog

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkInteropTest.java
@@ -127,7 +127,6 @@ public class DiscoveryNetworkInteropTest {
             localNodeRecord,
             Bytes.wrap(localPrivKey),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("server-1"),
             Schedulers.createDefault().newSingleThreadDaemon("client-1"));
 
     //    CountDownLatch randomSent1to2 = new CountDownLatch(1);
@@ -377,7 +376,6 @@ public class DiscoveryNetworkInteropTest {
             nodeRecord1,
             Bytes.wrap(privKey1),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("server-1"),
             Schedulers.createDefault().newSingleThreadDaemon("client-1"));
 
     Flux.from(discoveryManager1.getOutgoingMessages())
@@ -496,7 +494,6 @@ public class DiscoveryNetworkInteropTest {
             nodeRecord1,
             Bytes.wrap(privKey1),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("server-1"),
             Schedulers.createDefault().newSingleThreadDaemon("client-1"));
 
     // 3) Expect standard 1 => 2 dialog

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -76,7 +76,6 @@ public class DiscoveryNetworkTest {
             nodeRecord1,
             nodePair1.getValue0(),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("server-1"),
             Schedulers.createDefault().newSingleThreadDaemon("tasks-1"));
     DiscoveryManagerImpl discoveryManager2 =
         new DiscoveryManagerImpl(
@@ -85,7 +84,6 @@ public class DiscoveryNetworkTest {
             nodeRecord2,
             nodePair2.getValue0(),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("server-2"),
             Schedulers.createDefault().newSingleThreadDaemon("tasks-2"));
 
     // 3) Expect standard 1 => 2 dialog

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -1,0 +1,86 @@
+package org.ethereum.beacon.discovery.integration;
+
+import static org.ethereum.beacon.discovery.util.Functions.PRIVKEY_SIZE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.BindException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.ethereum.beacon.discovery.DiscoveryManager;
+import org.ethereum.beacon.discovery.DiscoveryManagerBuilder;
+import org.ethereum.beacon.discovery.schema.EnrField;
+import org.ethereum.beacon.discovery.schema.EnrFieldV4;
+import org.ethereum.beacon.discovery.schema.IdentitySchema;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.util.Functions;
+import org.ethereum.beacon.discovery.util.Utils;
+import org.javatuples.Pair;
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.ECKeyPair;
+
+public class DiscoveryIntegrationTest {
+  private static final Logger logger = LogManager.getLogger();
+  private int nextPort = 9000;
+
+  @Test
+  public void shouldSuccessfullyCommunicateWithBootnode() throws Exception {
+    final DiscoveryManager bootnode = createDiscoveryClient();
+    final DiscoveryManager client = createDiscoveryClient(bootnode.getLocalNodeRecord());
+    final CompletableFuture<Void> pingResult = client.ping(bootnode.getLocalNodeRecord());
+    waitFor(pingResult);
+    assertTrue(pingResult.isDone());
+    assertFalse(pingResult.isCompletedExceptionally());
+
+    final CompletableFuture<Void> findNodesResult =
+        client.findNodes(bootnode.getLocalNodeRecord(), 0);
+    waitFor(findNodesResult);
+    assertTrue(pingResult.isDone());
+    assertFalse(pingResult.isCompletedExceptionally());
+  }
+
+  private DiscoveryManager createDiscoveryClient(final NodeRecord... bootnodes) throws Exception {
+    final ECKeyPair keyPair = Functions.generateECKeyPair();
+    final Bytes privateKey =
+        Bytes.wrap(Utils.extractBytesFromUnsignedBigInt(keyPair.getPrivateKey(), PRIVKEY_SIZE));
+
+    int maxPort = nextPort + 10;
+    for (int port = nextPort++; port < maxPort; port = nextPort++) {
+      final NodeRecord nodeRecord =
+          NodeRecordFactory.DEFAULT.createFromValues(
+              UInt64.ONE,
+              Pair.with(EnrField.ID, IdentitySchema.V4),
+              Pair.with(EnrField.IP_V4, Bytes.fromHexString("0x7F000001")),
+              Pair.with(EnrField.UDP_V4, port),
+              Pair.with(
+                  EnrFieldV4.PKEY_SECP256K1, Functions.derivePublicKeyFromPrivate(privateKey)));
+      nodeRecord.sign(privateKey);
+      final DiscoveryManager discoveryManager =
+          new DiscoveryManagerBuilder()
+              .localNodeRecord(nodeRecord)
+              .privateKey(privateKey)
+              .bootnodes(bootnodes)
+              .build();
+      try {
+        waitFor(discoveryManager.start());
+        return discoveryManager;
+      } catch (final Exception e) {
+        if (e.getCause() instanceof BindException) {
+          logger.info("Port conflict detected, retrying with new port", e);
+        } else {
+          throw e;
+        }
+      }
+    }
+    throw new IllegalStateException("Could not find a free port after multiple attempts");
+  }
+
+  private void waitFor(final CompletableFuture<?> future) throws Exception {
+    future.get(5, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.BindException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -24,12 +26,19 @@ import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
 import org.ethereum.beacon.discovery.util.Functions;
 import org.ethereum.beacon.discovery.util.Utils;
 import org.javatuples.Pair;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.web3j.crypto.ECKeyPair;
 
 public class DiscoveryIntegrationTest {
   private static final Logger logger = LogManager.getLogger();
   private int nextPort = 9000;
+  private List<DiscoveryManager> managers = new ArrayList<>();
+
+  @AfterEach
+  public void tearDown() {
+    managers.forEach(DiscoveryManager::stop);
+  }
 
   @Test
   public void shouldSuccessfullyCommunicateWithBootnode() throws Exception {
@@ -71,8 +80,10 @@ public class DiscoveryIntegrationTest {
               .build();
       try {
         waitFor(discoveryManager.start());
+        managers.add(discoveryManager);
         return discoveryManager;
       } catch (final Exception e) {
+        discoveryManager.stop();
         if (e.getCause() instanceof BindException) {
           logger.info("Port conflict detected, retrying with new port", e);
         } else {

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -1,3 +1,6 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.ethereum.beacon.discovery.integration;
 
 import static org.ethereum.beacon.discovery.util.Functions.PRIVKEY_SIZE;

--- a/src/test/java/org/ethereum/beacon/discovery/mock/DiscoveryManagerNoNetwork.java
+++ b/src/test/java/org/ethereum/beacon/discovery/mock/DiscoveryManagerNoNetwork.java
@@ -57,6 +57,7 @@ public class DiscoveryManagerNoNetwork implements DiscoveryManager {
   private final Pipeline outgoingPipeline = new PipelineImpl();
   private final NodeRecordFactory nodeRecordFactory =
       NODE_RECORD_FACTORY_NO_VERIFICATION; // no signature verification
+  private final NodeRecord homeNodeRecord;
 
   public DiscoveryManagerNoNetwork(
       NodeTable nodeTable,
@@ -65,6 +66,7 @@ public class DiscoveryManagerNoNetwork implements DiscoveryManager {
       Bytes homeNodePrivateKey,
       Publisher<Bytes> incomingPackets,
       Scheduler taskScheduler) {
+    homeNodeRecord = homeNode;
     AuthTagRepository authTagRepo = new AuthTagRepository();
     this.incomingPackets = incomingPackets;
     NodeIdToSession nodeIdToSession =
@@ -98,14 +100,20 @@ public class DiscoveryManagerNoNetwork implements DiscoveryManager {
   }
 
   @Override
-  public void start() {
+  public CompletableFuture<Void> start() {
     incomingPipeline.build();
     outgoingPipeline.build();
     Flux.from(incomingPackets).subscribe(incomingPipeline::push);
+    return CompletableFuture.completedFuture(null);
   }
 
   @Override
   public void stop() {}
+
+  @Override
+  public NodeRecord getLocalNodeRecord() {
+    return homeNodeRecord;
+  }
 
   private CompletableFuture<Void> executeTaskImpl(
       NodeRecord nodeRecord, TaskType taskType, TaskOptions taskOptions) {


### PR DESCRIPTION
Introduces a builder to make instantiation easier in the standard case.
Report port conflicts and other startup errors back to the caller of start.
Add integration test to ensure ping and findNodes works in a simple case.