### PR TITLE
Validate the node record is signed correctly in AuthHeaderResponse

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
@@ -56,9 +56,12 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
         .getNodeRecords()
         .forEach(
             nodeRecordV5 -> {
-              nodeRecordV5.verify();
+              if (!nodeRecordV5.isValid()) {
+                logger.debug("Rejecting invalid node record {}", nodeRecordV5);
+                return;
+              }
               NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeRecordV5);
-              if (!session.getNodeTable().getNode(nodeRecordV5.getNodeId()).isPresent()) {
+              if (session.getNodeTable().getNode(nodeRecordV5.getNodeId()).isEmpty()) {
                 session.getNodeTable().save(nodeRecordInfo);
               }
               session.putRecordInBucket(nodeRecordInfo);

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaInterpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaInterpreter.java
@@ -23,10 +23,8 @@ public interface IdentitySchemaInterpreter {
   void sign(NodeRecord nodeRecord, Object signOptions);
 
   /** Verifies that `nodeRecord` is of scheme implementation */
-  default void verify(NodeRecord nodeRecord) {
-    if (!nodeRecord.getIdentityScheme().equals(getScheme())) {
-      throw new RuntimeException("Interpreter and node record schemes do not match!");
-    }
+  default boolean isValid(NodeRecord nodeRecord) {
+    return nodeRecord.getIdentityScheme().equals(getScheme());
   }
 
   /** Delivers nodeId according to identity scheme scheme */

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -5,10 +5,7 @@
 package org.ethereum.beacon.discovery.schema;
 
 import static org.ethereum.beacon.discovery.schema.EnrField.IP_V4;
-import static org.ethereum.beacon.discovery.schema.EnrField.UDP_V4;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -21,7 +18,6 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.apache.tuweni.units.bigints.UInt64;
-import org.ethereum.beacon.discovery.util.Functions;
 import org.javatuples.Pair;
 import org.web3j.rlp.RlpEncoder;
 import org.web3j.rlp.RlpList;
@@ -69,24 +65,6 @@ public class NodeRecord {
       List<Pair<String, Object>> fieldKeyPairs) {
     NodeRecord nodeRecord = new NodeRecord(identitySchemaInterpreter, seq);
     fieldKeyPairs.forEach(objects -> nodeRecord.set(objects.getValue0(), objects.getValue1()));
-    return nodeRecord;
-  }
-
-  public static NodeRecord createNodeRecord(byte[] privateKey, String networkInterface, int port)
-      throws UnknownHostException {
-    Bytes addressBytes = Bytes.wrap(InetAddress.getByName(networkInterface).getAddress());
-    Bytes ip = Bytes.concatenate(Bytes.wrap(new byte[4 - addressBytes.size()]), addressBytes);
-    NodeRecord nodeRecord =
-        NodeRecordFactory.DEFAULT.createFromValues(
-            UInt64.ZERO,
-            Pair.with(EnrField.ID, IdentitySchema.V4),
-            Pair.with(IP_V4, ip),
-            Pair.with(
-                EnrFieldV4.PKEY_SECP256K1,
-                Functions.derivePublicKeyFromPrivate(Bytes.wrap(privateKey))),
-            Pair.with(UDP_V4, port));
-    nodeRecord.sign(Bytes.wrap(privateKey));
-    nodeRecord.verify();
     return nodeRecord;
   }
 
@@ -165,8 +143,8 @@ public class NodeRecord {
     return Objects.hash(seq, signature, fields);
   }
 
-  public void verify() {
-    identitySchemaInterpreter.verify(this);
+  public boolean isValid() {
+    return identitySchemaInterpreter.isValid(this);
   }
 
   public void sign(Object signOptions) {

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeTableStorageFactoryImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeTableStorageFactoryImpl.java
@@ -4,6 +4,8 @@
 
 package org.ethereum.beacon.discovery.storage;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -46,7 +48,7 @@ public class NodeTableStorageFactoryImpl implements NodeTableStorageFactory {
           .get()
           .forEach(
               nodeRecord -> {
-                nodeRecord.verify();
+                checkArgument(nodeRecord.isValid(), "Invalid bootnode: " + nodeRecord.asEnr());
                 NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeRecord);
                 nodeTableStorage.get().save(nodeRecordInfo);
               });
@@ -59,7 +61,7 @@ public class NodeTableStorageFactoryImpl implements NodeTableStorageFactory {
             .map(nr -> nr.getNode().getSeq())
             .orElse(UInt64.ZERO);
     NodeRecord updatedHomeNodeRecord = homeNodeProvider.apply(oldSeq);
-    updatedHomeNodeRecord.verify();
+    checkArgument(updatedHomeNodeRecord.isValid(), "Local node record is invalid");
     nodeTableStorage.getHomeNodeSource().set(NodeRecordInfo.createDefault(updatedHomeNodeRecord));
 
     return nodeTableStorage;

--- a/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
@@ -9,6 +9,7 @@ import static org.web3j.crypto.Sign.CURVE_PARAMS;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -84,7 +85,7 @@ public class Functions {
    * @return whether `signature` reflects message `x` signed with `pubkey`
    */
   public static boolean verifyECDSASignature(Bytes signature, Bytes x, Bytes pubKey) {
-    assert pubKey.size() == 33;
+    Preconditions.checkArgument(pubKey.size() == 33, "Invalid public key size");
     ECPoint ecPoint = Functions.publicKeyToPoint(pubKey);
     Bytes pubKeyUncompressed = Bytes.wrap(ecPoint.getEncoded(false)).slice(1);
     ECDSASignature ecdsaSignature =

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkInteropTest.java
@@ -89,7 +89,7 @@ public class DiscoveryNetworkInteropTest {
     NodeRecord remoteNodeRecord = NodeRecordFactory.DEFAULT.fromBase64(remoteHostEnr);
     //    NodeRecord remoteNodeRecord =
     // NODE_RECORD_FACTORY_NO_VERIFICATION.fromBase64(remoteHostEnr);
-    remoteNodeRecord.verify();
+    Assertions.assertTrue(remoteNodeRecord.isValid());
     Assertions.assertNotNull(remoteNodeRecord);
     System.out.println("remoteEnr:" + remoteNodeRecord.asBase64());
     System.out.println("remoteNodeId:" + remoteNodeRecord.getNodeId());
@@ -229,7 +229,7 @@ public class DiscoveryNetworkInteropTest {
       // nodeRecord1.serializeNoSignature());
       //      nodeRecord1.setSignature(signature1);
       nodeRecord1.sign(Bytes.wrap(privKey1));
-      nodeRecord1.verify();
+      Assertions.assertTrue(nodeRecord1.isValid());
       return new Pair(nodeRecord1, privKey1);
     } catch (Exception e) {
       e.printStackTrace();
@@ -351,7 +351,7 @@ public class DiscoveryNetworkInteropTest {
                 Bytes.wrap(extractBytesFromUnsignedBigInt(keyPair1.getPublicKey(), PUBKEY_SIZE))));
     Bytes signature1 = Functions.sign(Bytes.wrap(privKey1), nodeRecord1.serializeNoSignature());
     nodeRecord1.setSignature(signature1);
-    nodeRecord1.verify();
+    Assertions.assertTrue(nodeRecord1.isValid());
 
     /// use discovery manager to connect to a remote discv5 peer
     Database database0 = Database.inMemoryDB();
@@ -449,7 +449,7 @@ public class DiscoveryNetworkInteropTest {
                 Bytes.wrap(extractBytesFromUnsignedBigInt(keyPair1.getPublicKey(), PUBKEY_SIZE))));
     Bytes signature1 = Functions.sign(Bytes.wrap(privKey1), nodeRecord1.serializeNoSignature());
     nodeRecord1.setSignature(signature1);
-    nodeRecord1.verify();
+    Assertions.assertTrue(nodeRecord1.isValid());
 
     // set remote service
     byte[] privKey = new byte[32];
@@ -468,7 +468,7 @@ public class DiscoveryNetworkInteropTest {
                 Bytes.wrap(extractBytesFromUnsignedBigInt(keyPair.getPublicKey(), PUBKEY_SIZE))));
     Bytes signature0 = Functions.sign(Bytes.wrap(privKey), nodeRecord0.serializeNoSignature());
     nodeRecord0.setSignature(signature0);
-    nodeRecord0.verify();
+    Assertions.assertTrue(nodeRecord0.isValid());
 
     NodeTableStorageFactoryImpl nodeTableStorageFactory = new NodeTableStorageFactoryImpl();
 

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -7,12 +7,12 @@ package org.ethereum.beacon.discovery;
 import static org.ethereum.beacon.discovery.TestUtil.SEED;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetAddress;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.ethereum.beacon.discovery.schema.EnrField;
@@ -91,7 +91,7 @@ public class NodeRecordTest {
                 EnrFieldV4.PKEY_SECP256K1,
                 Functions.derivePublicKeyFromPrivate(Bytes.wrap(privKey))));
     nodeRecord0.sign(Bytes.wrap(privKey));
-    nodeRecord0.verify();
+    assertTrue(nodeRecord0.isValid());
     NodeRecord nodeRecord1 =
         NodeRecordFactory.DEFAULT.createFromValues(
             UInt64.valueOf(1),
@@ -103,17 +103,11 @@ public class NodeRecordTest {
                 EnrFieldV4.PKEY_SECP256K1,
                 Functions.derivePublicKeyFromPrivate(Bytes.wrap(privKey))));
     nodeRecord1.sign(Bytes.wrap(privKey));
-    nodeRecord1.verify();
+    assertTrue(nodeRecord1.isValid());
     assertNotEquals(nodeRecord0.serialize(), nodeRecord1.serialize());
     assertNotEquals(nodeRecord0.getSignature(), nodeRecord1.getSignature());
     nodeRecord1.setSignature(nodeRecord0.getSignature());
-    AtomicBoolean exceptionThrown = new AtomicBoolean(false);
-    try {
-      nodeRecord1.verify();
-    } catch (AssertionError ex) {
-      exceptionThrown.set(true);
-    }
-    assertTrue(exceptionThrown.get());
+    assertFalse(nodeRecord1.isValid());
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -5,6 +5,7 @@ package org.ethereum.beacon.discovery.integration;
 
 import static org.ethereum.beacon.discovery.util.Functions.PRIVKEY_SIZE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.BindException;
@@ -12,12 +13,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.ethereum.beacon.discovery.DiscoveryManager;
 import org.ethereum.beacon.discovery.DiscoveryManagerBuilder;
+import org.ethereum.beacon.discovery.mock.IdentitySchemaV4InterpreterMock;
 import org.ethereum.beacon.discovery.schema.EnrField;
 import org.ethereum.beacon.discovery.schema.EnrFieldV4;
 import org.ethereum.beacon.discovery.schema.IdentitySchema;
@@ -56,22 +59,44 @@ public class DiscoveryIntegrationTest {
     assertFalse(pingResult.isCompletedExceptionally());
   }
 
+  @Test
+  public void shouldNotSuccessfullyPingBootnodeWhenNodeRecordIsNotSigned() throws Exception {
+    final DiscoveryManager bootnode = createDiscoveryClient();
+    final DiscoveryManager client = createDiscoveryClient(false, bootnode.getLocalNodeRecord());
+
+    final CompletableFuture<Void> pingResult = client.ping(bootnode.getLocalNodeRecord());
+    assertThrows(TimeoutException.class, () -> waitFor(pingResult));
+  }
+
   private DiscoveryManager createDiscoveryClient(final NodeRecord... bootnodes) throws Exception {
+    return createDiscoveryClient(true, bootnodes);
+  }
+
+  private DiscoveryManager createDiscoveryClient(
+      final boolean signNodeRecord, final NodeRecord... bootnodes) throws Exception {
     final ECKeyPair keyPair = Functions.generateECKeyPair();
     final Bytes privateKey =
         Bytes.wrap(Utils.extractBytesFromUnsignedBigInt(keyPair.getPrivateKey(), PRIVKEY_SIZE));
 
     int maxPort = nextPort + 10;
     for (int port = nextPort++; port < maxPort; port = nextPort++) {
+      final NodeRecordFactory nodeRecordFactory =
+          signNodeRecord
+              ? NodeRecordFactory.DEFAULT
+              // We're not signing the record so use an identity schema that won't check the
+              // signature locally. The other side should still validate it.
+              : new NodeRecordFactory(new IdentitySchemaV4InterpreterMock());
       final NodeRecord nodeRecord =
-          NodeRecordFactory.DEFAULT.createFromValues(
+          nodeRecordFactory.createFromValues(
               UInt64.ONE,
               Pair.with(EnrField.ID, IdentitySchema.V4),
               Pair.with(EnrField.IP_V4, Bytes.fromHexString("0x7F000001")),
               Pair.with(EnrField.UDP_V4, port),
               Pair.with(
                   EnrFieldV4.PKEY_SECP256K1, Functions.derivePublicKeyFromPrivate(privateKey)));
-      nodeRecord.sign(privateKey);
+      if (signNodeRecord) {
+        nodeRecord.sign(privateKey);
+      }
       final DiscoveryManager discoveryManager =
           new DiscoveryManagerBuilder()
               .localNodeRecord(nodeRecord)

--- a/src/test/java/org/ethereum/beacon/discovery/mock/IdentitySchemaV4InterpreterMock.java
+++ b/src/test/java/org/ethereum/beacon/discovery/mock/IdentitySchemaV4InterpreterMock.java
@@ -10,8 +10,9 @@ import org.ethereum.beacon.discovery.schema.NodeRecord;
 
 public class IdentitySchemaV4InterpreterMock extends IdentitySchemaV4Interpreter {
   @Override
-  public void verify(NodeRecord nodeRecord) {
+  public boolean isValid(NodeRecord nodeRecord) {
     // Don't verify signature
+    return true;
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Switches from using `assert` which is disabled in production to using return values when checking node records are valid.  Reject handshakes which are invalid correctly.