### PR TITLE
Remove assert usage in favour of either return values or precondition checks

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
@@ -69,7 +69,7 @@ public class FindNodeHandler implements MessageHandler<FindNodeMessage> {
                 MessagePacket.create(
                     session.getHomeNodeId(),
                     session.getNodeId(),
-                    session.getAuthTag().get(),
+                    session.getAuthTag().orElseThrow(),
                     session.getInitiatorKey(),
                     DiscoveryV5Message.from(
                         new NodesMessage(

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
@@ -22,7 +22,7 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
   public void handle(NodesMessage message, NodeSession session) {
     // NODES total count handling
     Optional<RequestInfo> requestInfoOpt = session.getRequestId(message.getRequestId());
-    if (!requestInfoOpt.isPresent()) {
+    if (requestInfoOpt.isEmpty()) {
       throw new RuntimeException(
           String.format(
               "Request #%s not found in session %s when handling message %s",

--- a/src/main/java/org/ethereum/beacon/discovery/packet/MessagePacket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/packet/MessagePacket.java
@@ -45,8 +45,6 @@ public class MessagePacket extends AbstractPacket {
     return create(tag, authTag, encryptedData);
   }
 
-  public void verify(Bytes expectedAuthTag) {}
-
   public Bytes getHomeNodeId(Bytes destNodeId) {
     verifyDecode();
     return Functions.hash(destNodeId).xor(decoded.tag, MutableBytes.create(decoded.tag.size()));

--- a/src/main/java/org/ethereum/beacon/discovery/packet/RandomPacket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/packet/RandomPacket.java
@@ -4,6 +4,7 @@
 
 package org.ethereum.beacon.discovery.packet;
 
+import com.google.common.base.Preconditions;
 import java.util.Random;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.util.Functions;
@@ -34,7 +35,10 @@ public class RandomPacket extends AbstractPacket {
   }
 
   public static RandomPacket create(Bytes tag, Bytes authTag, Bytes randomBytes) {
-    assert randomBytes.size() >= MIN_RANDOM_BYTES; // At least 44 bytes, spec defined
+    // At least 44 bytes, spec defined
+    Preconditions.checkArgument(
+        randomBytes.size() >= MIN_RANDOM_BYTES,
+        "Random bytes must be at least " + MIN_RANDOM_BYTES + " bytes");
     byte[] authTagRlp = RlpEncoder.encode(RlpString.create(authTag.toArray()));
     Bytes authTagEncoded = Bytes.wrap(authTagRlp);
     return new RandomPacket(Bytes.concatenate(tag, authTagEncoded, randomBytes));

--- a/src/main/java/org/ethereum/beacon/discovery/packet/UnknownPacket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/packet/UnknownPacket.java
@@ -4,6 +4,7 @@
 
 package org.ethereum.beacon.discovery.packet;
 
+import com.google.common.base.Preconditions;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.type.Hashes;
 
@@ -43,7 +44,7 @@ public class UnknownPacket extends AbstractPacket {
   //
   // src-node-id      = xor(sha256(dest-node-id), tag)
   public Bytes getSourceNodeId(Bytes destNodeId) {
-    assert !isWhoAreYouPacket(destNodeId);
+    Preconditions.checkArgument(!isWhoAreYouPacket(destNodeId));
     Bytes xorTag = getBytes().slice(0, 32);
     return Hashes.sha256(destNodeId).xor(xorTag);
   }

--- a/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
@@ -71,10 +71,10 @@ public class WhoAreYouPacket extends AbstractPacket {
     return decoded.enrSeq;
   }
 
-  public void verify(Bytes destNodeId, Bytes expectedAuthTag) {
+  public boolean isValid(Bytes destNodeId, Bytes expectedAuthTag) {
     decode();
-    assert Functions.hash(Bytes.concatenate(destNodeId, MAGIC_BYTES)).equals(decoded.magic);
-    assert expectedAuthTag.equals(getAuthTag());
+    return Functions.hash(Bytes.concatenate(destNodeId, MAGIC_BYTES)).equals(decoded.magic)
+        && expectedAuthTag.equals(getAuthTag());
   }
 
   private synchronized void decode() {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
@@ -42,14 +42,6 @@ public class MessagePacketHandler implements EnvelopeHandler {
     try {
       packet.decode(session.getRecipientKey());
       envelope.put(Field.MESSAGE, packet.getMessage());
-    } catch (AssertionError ex) {
-      logger.error(
-          String.format(
-              "Verification not passed for message [%s] from node %s in status %s",
-              packet, session.getNodeRecord(), session.getStatus()));
-      envelope.remove(Field.PACKET_MESSAGE);
-      envelope.put(Field.BAD_PACKET, packet);
-      return;
     } catch (Exception ex) {
       String error =
           String.format(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NotExpectedIncomingPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NotExpectedIncomingPacketHandler.java
@@ -71,11 +71,6 @@ public class NotExpectedIncomingPacketHandler implements EnvelopeHandler {
               idNonce,
               session.getNodeRecord().map(NodeRecord::getSeq).orElse(UInt64.ZERO));
       session.sendOutgoing(whoAreYouPacket);
-    } catch (AssertionError ex) {
-      logger.info(
-          String.format(
-              "Verification not passed for message [%s] from node %s in status %s",
-              unknownPacket, session.getNodeRecord(), session.getStatus()));
     } catch (Exception ex) {
       String error =
           String.format(

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery.schema;
 
 import static org.ethereum.beacon.discovery.schema.EnrField.IP_V4;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -160,7 +161,7 @@ public class NodeRecord {
   }
 
   private RlpList asRlpImpl(boolean withSignature) {
-    assert getSeq() != null;
+    Preconditions.checkNotNull(getSeq(), "Missing sequence number");
     // content   = [seq, k, v, ...]
     // signature = sign(content)
     // record    = [signature, seq, k, v, ...]
@@ -192,7 +193,8 @@ public class NodeRecord {
   private Bytes serializeImpl(boolean withSignature) {
     RlpType rlpRecord = withSignature ? asRlp() : asRlpNoSignature();
     byte[] bytes = RlpEncoder.encode(rlpRecord);
-    assert bytes.length <= MAX_ENCODED_SIZE;
+    Preconditions.checkArgument(
+        bytes.length <= MAX_ENCODED_SIZE, "Node record exceeds maximum encoded size");
     return Bytes.wrap(bytes);
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -4,6 +4,8 @@
 
 package org.ethereum.beacon.discovery.schema;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.ethereum.beacon.discovery.task.TaskStatus.AWAIT;
 
 import java.util.HashSet;
@@ -238,9 +240,12 @@ public class NodeSession {
   }
 
   public synchronized void clearRequestId(Bytes requestId, TaskType taskType) {
-    RequestInfo requestInfo = clearRequestId(requestId);
+    final RequestInfo requestInfo = clearRequestId(requestId);
+    checkNotNull(requestInfo, "Attempting to clear an unknown request");
+    checkArgument(
+        taskType.equals(requestInfo.getTaskType()),
+        "Attempting to clear a request but task type did not match");
     requestInfo.getFuture().complete(null);
-    assert taskType.equals(requestInfo.getTaskType());
   }
 
   /** Updates nodeRecord {@link NodeStatus} to ACTIVE of the node associated with this session */

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery;
 
 import static org.ethereum.beacon.discovery.TestUtil.NODE_RECORD_FACTORY_NO_VERIFICATION;
 import static org.ethereum.beacon.discovery.TestUtil.TEST_SERIALIZER;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -105,11 +106,11 @@ public class DiscoveryInteropTest {
     int distance = Functions.logDistance(nodeRecord1.getNodeId(), nodeRecord2.getNodeId());
     discoveryManager1.findNodes(nodeRecord2, distance);
 
-    assert randomSent1to2.await(1, TimeUnit.SECONDS);
-    //    assert whoareyouSent2to1.await(1, TimeUnit.SECONDS);
+    assertTrue(randomSent1to2.await(1, TimeUnit.SECONDS));
+    //    assertTrue(whoareyouSent2to1.await(1, TimeUnit.SECONDS));
     int distance1To2 = Functions.logDistance(nodeRecord1.getNodeId(), nodeRecord2.getNodeId());
     Assertions.assertFalse(nodeBucketStorage1.get(distance1To2).isPresent());
-    assert authPacketSent1to2.await(1, TimeUnit.SECONDS);
+    assertTrue(authPacketSent1to2.await(1, TimeUnit.SECONDS));
     Thread.sleep(1000);
     // 1 sent findnodes to 2, received only (2) in answer
     // 1 added 2 to its nodeBuckets, because its now checked, but not before

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkInteropTest.java
@@ -526,13 +526,13 @@ public class DiscoveryNetworkInteropTest {
     discoveryManager1.start();
     discoveryManager1.findNodes(nodeRecord0, 0);
 
-    //    assert randomSent1to2.await(10, TimeUnit.SECONDS);
-    //    assert whoareyouSent2to1.await(10, TimeUnit.SECONDS);
+    //    assertTrue(randomSent1to2.await(10, TimeUnit.SECONDS));
+    //    assertTrue(whoareyouSent2to1.await(10, TimeUnit.SECONDS));
     //    int distance1To2 = Functions.logDistance(nodeRecord1.getNodeId(),
     // nodeRecord2.getNodeId());
     //    assertFalse(nodeBucketStorage1.get(distance1To2).isPresent());
-    //    assert authPacketSent1to2.await(10, TimeUnit.SECONDS);
-    //    assert nodesSent2to1.await(10, TimeUnit.SECONDS);
+    //    assertTrue(authPacketSent1to2.await(10, TimeUnit.SECONDS));
+    //    assertTrue(nodesSent2to1.await(10, TimeUnit.SECONDS));
     //    Thread.sleep(500);
     // 1 sent findnodes to 2, received only (2) in answer, because 3 is not checked
     // 1 added 2 to its nodeBuckets, because its now checked, but not before

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -8,6 +8,7 @@ import static org.ethereum.beacon.discovery.TestUtil.NODE_RECORD_FACTORY_NO_VERI
 import static org.ethereum.beacon.discovery.TestUtil.TEST_SERIALIZER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -133,12 +134,12 @@ public class DiscoveryNetworkTest {
     discoveryManager1.start();
     discoveryManager1.findNodes(nodeRecord2, 0);
 
-    assert randomSent1to2.await(1, TimeUnit.SECONDS);
-    assert whoareyouSent2to1.await(1, TimeUnit.SECONDS);
+    assertTrue(randomSent1to2.await(1, TimeUnit.SECONDS));
+    assertTrue(whoareyouSent2to1.await(1, TimeUnit.SECONDS));
     int distance1To2 = Functions.logDistance(nodeRecord1.getNodeId(), nodeRecord2.getNodeId());
     assertFalse(nodeBucketStorage1.get(distance1To2).isPresent());
-    assert authPacketSent1to2.await(1, TimeUnit.SECONDS);
-    assert nodesSent2to1.await(1, TimeUnit.SECONDS);
+    assertTrue(authPacketSent1to2.await(1, TimeUnit.SECONDS));
+    assertTrue(nodesSent2to1.await(1, TimeUnit.SECONDS));
     Thread.sleep(50);
     // 1 sent findnodes to 2, received only (2) in answer, because 3 is not checked
     // 1 added 2 to its nodeBuckets, because its now checked, but not before

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNoNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNoNetworkTest.java
@@ -7,6 +7,7 @@ package org.ethereum.beacon.discovery;
 import static org.ethereum.beacon.discovery.TestUtil.TEST_SERIALIZER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -134,12 +135,12 @@ public class DiscoveryNoNetworkTest {
     discoveryManager1.start();
     discoveryManager1.findNodes(nodeRecord2, 0);
 
-    assert randomSent1to2.await(1, TimeUnit.SECONDS);
-    assert whoareyouSent2to1.await(1, TimeUnit.SECONDS);
+    assertTrue(randomSent1to2.await(1, TimeUnit.SECONDS));
+    assertTrue(whoareyouSent2to1.await(1, TimeUnit.SECONDS));
     int distance1To2 = Functions.logDistance(nodeRecord1.getNodeId(), nodeRecord2.getNodeId());
     assertFalse(nodeBucketStorage1.get(distance1To2).isPresent());
-    assert authPacketSent1to2.await(1, TimeUnit.SECONDS);
-    assert nodesSent2to1.await(1, TimeUnit.SECONDS);
+    assertTrue(authPacketSent1to2.await(1, TimeUnit.SECONDS));
+    assertTrue(nodesSent2to1.await(1, TimeUnit.SECONDS));
     Thread.sleep(50);
     // 1 sent findnodes to 2, received 0 nodes in answer, because 3 is not checked
     // 1 added 2 to its nodeBuckets, because its now checked, but not before

--- a/src/test/java/org/ethereum/beacon/discovery/FunctionsTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/FunctionsTest.java
@@ -8,6 +8,7 @@ import static org.ethereum.beacon.discovery.packet.AuthHeaderMessagePacket.creat
 import static org.ethereum.beacon.discovery.util.Functions.PRIVKEY_SIZE;
 import static org.ethereum.beacon.discovery.util.Functions.PUBKEY_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.math.ec.ECPoint;
@@ -151,7 +152,7 @@ public class FunctionsTest {
 
     Bytes message =
         Bytes.concatenate(Bytes.wrap("discovery-id-nonce".getBytes()), nonce, ephemeralKey);
-    assert Functions.verifyECDSASignature(idNonceSig, Functions.hash(message), pubKey);
+    assertTrue(Functions.verifyECDSASignature(idNonceSig, Functions.hash(message), pubKey));
   }
 
   @Test
@@ -171,8 +172,9 @@ public class FunctionsTest {
                             ECKeyPair.create(privKey.toArray()).getPublicKey(), 64)))
                 .getEncoded(true));
     Bytes idNonceSig = AuthHeaderMessagePacket.signIdNonce(idNonce, privKey, ephemeralPubkey);
-    assert Functions.verifyECDSASignature(
-        idNonceSig, Functions.hash(createIdNonceMessage(idNonce, ephemeralPubkey)), pubKey);
+    assertTrue(
+        Functions.verifyECDSASignature(
+            idNonceSig, Functions.hash(createIdNonceMessage(idNonce, ephemeralPubkey)), pubKey));
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -151,7 +151,7 @@ public class HandshakeHandlersTest {
     CompletableFuture<Void> future = new CompletableFuture<>();
     nodeSessionAt1For2.createNextRequest(TaskType.FINDNODE, new TaskOptions(true), future);
     whoAreYouPacketHandlerNode1.handle(envelopeAt1From2);
-    assert outgoing1PacketsSemaphore.tryAcquire(1, 1, TimeUnit.SECONDS);
+    assertTrue(outgoing1PacketsSemaphore.tryAcquire(1, 1, TimeUnit.SECONDS));
     outgoing1PacketsSemaphore.release();
 
     // Node2 handle AuthHeaderPacket and finish handshake
@@ -184,7 +184,7 @@ public class HandshakeHandlersTest {
 
     MessageHandler messageHandler = new MessageHandler(NODE_RECORD_FACTORY_NO_VERIFICATION);
     messageHandler.handle(envelopeAt1From2WithMessage);
-    assert outgoing1PacketsSemaphore.tryAcquire(2, 1, TimeUnit.SECONDS);
+    assertTrue(outgoing1PacketsSemaphore.tryAcquire(2, 1, TimeUnit.SECONDS));
 
     // Node 2 handles message from Node 1
     MessagePacketHandler messagePacketHandler2 = new MessagePacketHandler();

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -55,8 +55,8 @@ public class DiscoveryIntegrationTest {
     final CompletableFuture<Void> findNodesResult =
         client.findNodes(bootnode.getLocalNodeRecord(), 0);
     waitFor(findNodesResult);
-    assertTrue(pingResult.isDone());
-    assertFalse(pingResult.isCompletedExceptionally());
+    assertTrue(findNodesResult.isDone());
+    assertFalse(findNodesResult.isCompletedExceptionally());
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketTest.java
@@ -33,8 +33,9 @@ public class NodeBucketTest {
 
     long lastRetrySaved = -1L;
     for (NodeRecordInfo nodeRecordInfo : nodeBucket.getNodeRecords()) {
-      assert nodeRecordInfo.getLastRetry()
-          >= lastRetrySaved; // Assert sorted by last retry, latest retry in the end
+      assertTrue(
+          nodeRecordInfo.getLastRetry()
+              >= lastRetrySaved); // Assert sorted by last retry, latest retry in the end
       lastRetrySaved = nodeRecordInfo.getLastRetry();
     }
     NodeRecordInfo willNotInsertNode =


### PR DESCRIPTION
## PR Description
The Java `assert` keyword is not enabled by default in production so we can't depend on any checks being run.  Replace those checks with either a return value where the error was handled as part of business logic or a `Preconditions` call where the check is expected to always pass and any failures indicate developer error.