### PR TITLE
Rename TCP_V4 and UDP_V4 to TCP and UDP

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -65,7 +65,7 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
     AuthTagRepository authTagRepo = new AuthTagRepository();
     this.discoveryServer =
         new NettyDiscoveryServerImpl(
-            ((Bytes) homeNode.get(EnrField.IP_V4)), (int) homeNode.get(EnrField.UDP_V4));
+            ((Bytes) homeNode.get(EnrField.IP_V4)), (int) homeNode.get(EnrField.UDP));
     NodeIdToSession nodeIdToSession =
         new NodeIdToSession(
             homeNode,

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/PingHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/PingHandler.java
@@ -22,7 +22,7 @@ public class PingHandler implements MessageHandler<PingMessage> {
             message.getRequestId(),
             nodeRecord.getSeq(),
             ((Bytes) nodeRecord.get(EnrField.IP_V4)), // bytes4
-            (int) nodeRecord.get(EnrField.UDP_V4));
+            (int) nodeRecord.get(EnrField.UDP));
     session.sendOutgoing(
         MessagePacket.create(
             session.getHomeNodeId(),

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
@@ -77,7 +77,7 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
     try {
       return new InetSocketAddress(
           InetAddress.getByAddress(((Bytes) recipient.get(EnrField.IP_V4)).toArray()), // bytes4
-          (int) recipient.get(EnrField.UDP_V4));
+          (int) recipient.get(EnrField.UDP));
     } catch (UnknownHostException e) {
       String error = String.format("Failed to resolve host for node record: %s", recipient);
       logger.error(error);

--- a/src/main/java/org/ethereum/beacon/discovery/schema/EnrField.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/EnrField.java
@@ -14,9 +14,9 @@ public class EnrField {
   // IPv4 address
   public static final String IP_V4 = "ip";
   // TCP port, integer
-  public static final String TCP_V4 = "tcp";
+  public static final String TCP = "tcp";
   // UDP port, integer
-  public static final String UDP_V4 = "udp";
+  public static final String UDP = "udp";
   // IPv6 address
   public static final String IP_V6 = "ip6";
   // IPv6-specific TCP port

--- a/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreterV4.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreterV4.java
@@ -23,8 +23,8 @@ public class EnrFieldInterpreterV4 implements EnrFieldInterpreter {
     fieldDecoders.put(
         EnrField.ID, rlpString -> IdentitySchema.fromString(new String(rlpString.getBytes())));
     fieldDecoders.put(EnrField.IP_V4, rlpString -> Bytes.wrap(rlpString.getBytes()));
-    fieldDecoders.put(EnrField.TCP_V4, rlpString -> rlpString.asPositiveBigInteger().intValue());
-    fieldDecoders.put(EnrField.UDP_V4, rlpString -> rlpString.asPositiveBigInteger().intValue());
+    fieldDecoders.put(EnrField.TCP, rlpString -> rlpString.asPositiveBigInteger().intValue());
+    fieldDecoders.put(EnrField.UDP, rlpString -> rlpString.asPositiveBigInteger().intValue());
     fieldDecoders.put(EnrField.IP_V6, rlpString -> Bytes.wrap(rlpString.getBytes()));
     fieldDecoders.put(EnrField.TCP_V6, rlpString -> rlpString.asPositiveBigInteger().intValue());
     fieldDecoders.put(EnrField.UDP_V6, rlpString -> rlpString.asPositiveBigInteger().intValue());

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -203,7 +203,7 @@ public class NodeRecord {
         + ", ipV4address="
         + fields.get(IP_V4)
         + ", udpPort="
-        + fields.get(EnrField.UDP_V4)
+        + fields.get(EnrField.UDP)
         + ", asBase64="
         + this.asBase64()
         + ", nodeId="

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordBuilder.java
@@ -65,11 +65,6 @@ public class NodeRecordBuilder {
     return this;
   }
 
-  public NodeRecordBuilder field(final String name, final Object value) {
-    fields.add(new EnrField(name, value));
-    return this;
-  }
-
   public NodeRecord build() {
     fields.add(new EnrField(EnrField.ID, IdentitySchema.V4));
     final NodeRecord nodeRecord = nodeRecordFactory.createFromValues(seq, fields);

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordBuilder.java
@@ -57,11 +57,16 @@ public class NodeRecordBuilder {
       final Bytes address = Bytes.wrap(inetAddress.getAddress());
       final boolean isIpV6 = inetAddress instanceof Inet6Address;
       fields.add(new EnrField(isIpV6 ? EnrField.IP_V6 : EnrField.IP_V4, address));
-      fields.add(new EnrField(isIpV6 ? EnrField.UDP_V6 : EnrField.UDP_V4, udpPort));
-      fields.add(new EnrField(isIpV6 ? EnrField.TCP_V6 : EnrField.TCP_V4, tcpPort));
+      fields.add(new EnrField(isIpV6 ? EnrField.UDP_V6 : EnrField.UDP, udpPort));
+      fields.add(new EnrField(isIpV6 ? EnrField.TCP_V6 : EnrField.TCP, tcpPort));
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Unable to resolve address: " + ipAddress);
     }
+    return this;
+  }
+
+  public NodeRecordBuilder field(final String name, final Object value) {
+    fields.add(new EnrField(name, value));
     return this;
   }
 

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -52,7 +52,7 @@ public class NodeRecordTest {
     assertArrayEquals(
         InetAddress.getByName(expectedHost).getAddress(),
         ((Bytes) nodeRecord.get(EnrField.IP_V4)).toArray());
-    assertEquals(expectedUdpPort, nodeRecord.get(EnrField.UDP_V4));
+    assertEquals(expectedUdpPort, nodeRecord.get(EnrField.UDP));
     //    assertEquals(expectedTcpPort, nodeRecord.get(EnrField.TCP_V4));
     assertEquals(expectedSeqNumber, nodeRecord.getSeq());
     assertEquals(expectedPublicKey, nodeRecord.get(EnrField.PKEY_SECP256K1));
@@ -66,7 +66,7 @@ public class NodeRecordTest {
     assertArrayEquals(
         InetAddress.getByName(expectedHost).getAddress(),
         ((Bytes) nodeRecordRestored.get(EnrField.IP_V4)).toArray());
-    assertEquals(expectedUdpPort, nodeRecordRestored.get(EnrField.UDP_V4));
+    assertEquals(expectedUdpPort, nodeRecordRestored.get(EnrField.UDP));
     //    assertEquals(expectedTcpPort, nodeRecordRestored.get(EnrField.TCP_V4));
     assertEquals(expectedSeqNumber, nodeRecordRestored.getSeq());
     assertEquals(expectedPublicKey, nodeRecordRestored.get(EnrField.PKEY_SECP256K1));
@@ -114,7 +114,7 @@ public class NodeRecordTest {
                 UInt64.valueOf(seq),
                 new EnrField(EnrField.ID, IdentitySchema.V4),
                 new EnrField(EnrField.IP_V4, ip),
-                new EnrField(EnrField.UDP_V4, port),
+                new EnrField(EnrField.UDP, port),
                 new EnrField(
                     EnrField.PKEY_SECP256K1, Functions.derivePublicKeyFromPrivate(privateKey)));
     nodeRecord.sign(privateKey);
@@ -139,6 +139,6 @@ public class NodeRecordTest {
         Bytes.fromHexString("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138"),
         nodeRecord.get(EnrField.PKEY_SECP256K1));
     assertEquals(Bytes.fromHexString("0x7F000001"), nodeRecord.get(EnrField.IP_V4));
-    assertEquals(30303, nodeRecord.get(EnrField.UDP_V4));
+    assertEquals(30303, nodeRecord.get(EnrField.UDP));
   }
 }


### PR DESCRIPTION
## PR Description
The `tcp` and `udp`  ENR fields are used for IPv4 but also as a fallback for IPv6.  Rename the constants to just `TCP` and `UDP` so this is clearer.