### PR TITLE
Ensure find nodes request completes when there are no results

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
@@ -33,7 +33,7 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
         requestInfo.getRemainingNodes() == null
             ? message.getTotal() - 1
             : requestInfo.getRemainingNodes() - 1;
-    if (newNodesCount == 0) {
+    if (newNodesCount <= 0) {
       session.clearRequestId(message.getRequestId(), TaskType.FINDNODE);
     } else {
       session.updateRequestInfo(

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -60,12 +60,16 @@ public class DiscoveryIntegrationTest {
     final DiscoverySystem bootnode = createDiscoveryClient();
     final DiscoverySystem client = createDiscoveryClient(bootnode.getLocalNodeRecord());
     final CompletableFuture<Void> pingResult = client.ping(bootnode.getLocalNodeRecord());
+    final Bytes bootnodeId = bootnode.getLocalNodeRecord().getNodeId();
+    final Bytes clientNodeId = client.getLocalNodeRecord().getNodeId();
+    final int distance = Functions.logDistance(clientNodeId, bootnodeId);
     waitFor(pingResult);
     assertTrue(pingResult.isDone());
     assertFalse(pingResult.isCompletedExceptionally());
 
+    // Find nodes at a distance we know has no node records to return.
     final CompletableFuture<Void> findNodesResult =
-        client.findNodes(bootnode.getLocalNodeRecord(), 10);
+        client.findNodes(bootnode.getLocalNodeRecord(), distance == 1 ? 2 : distance - 1);
     waitFor(findNodesResult);
     assertTrue(findNodesResult.isDone());
     assertFalse(findNodesResult.isCompletedExceptionally());

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -56,6 +56,22 @@ public class DiscoveryIntegrationTest {
   }
 
   @Test
+  public void shouldCompleteFindnodesFutureWhenNoNodesAreFound() throws Exception {
+    final DiscoverySystem bootnode = createDiscoveryClient();
+    final DiscoverySystem client = createDiscoveryClient(bootnode.getLocalNodeRecord());
+    final CompletableFuture<Void> pingResult = client.ping(bootnode.getLocalNodeRecord());
+    waitFor(pingResult);
+    assertTrue(pingResult.isDone());
+    assertFalse(pingResult.isCompletedExceptionally());
+
+    final CompletableFuture<Void> findNodesResult =
+        client.findNodes(bootnode.getLocalNodeRecord(), 10);
+    waitFor(findNodesResult);
+    assertTrue(findNodesResult.isDone());
+    assertFalse(findNodesResult.isCompletedExceptionally());
+  }
+
+  @Test
   public void shouldNotSuccessfullyPingBootnodeWhenNodeRecordIsNotSigned() throws Exception {
     final DiscoverySystem bootnode = createDiscoveryClient();
     final DiscoverySystem client = createDiscoveryClient(false, bootnode.getLocalNodeRecord());


### PR DESCRIPTION
## PR Description
When a `FINDNODE` request was sent that didn't find any nodes, the returned `CompletableFuture` would time out instead of completing successfully.