### PR TITLE
Validate the distance of returned nodes matches what we requested

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
   implementation 'org.web3j:core'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testImplementation 'org.mockito:mockito-core'
 
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -19,7 +19,7 @@ dependencyManagement {
     dependency 'org.bouncycastle:bcprov-jdk15on:1.60'
 
     dependency 'org.web3j:core:4.2.0'
-
+    dependency 'org.mockito:mockito-core:3.1.0'
 
     dependencySet(group: 'org.apache.tuweni', version: '0.9.0') {
       entry 'tuweni-bytes'

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
@@ -82,7 +82,6 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
     final int actualDistance = Functions.logDistance(nodeRecordV5.getNodeId(), session.getNodeId());
     final int requestedDistance = requestInfo.getDistance();
     if (actualDistance != requestedDistance) {
-
       logger.debug(
           "Rejecting node record {} received from {} because distance was not {}.",
           nodeRecordV5.getNodeId(),

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -46,7 +46,7 @@ public class DiscoveryInteropTest {
   @SuppressWarnings({"DoubleBraceInitialization"})
   public void testInterop() throws Exception {
     // 1) start 2 nodes
-    NodeInfo nodePair1 = TestUtil.generateNode(40412, true);
+    NodeInfo nodePair1 = TestUtil.generateNode(40412);
     System.out.println(String.format("Node %s started", nodePair1.getNodeRecord().getNodeId()));
     NodeRecord nodeRecord1 = nodePair1.getNodeRecord();
     NodeRecord nodeRecord2 =

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -36,8 +36,8 @@ public class DiscoveryNetworkTest {
   @Test
   public void test() throws Exception {
     // 1) start 2 nodes
-    NodeInfo nodePair1 = TestUtil.generateNode(30303, true);
-    NodeInfo nodePair2 = TestUtil.generateNode(30304, true);
+    NodeInfo nodePair1 = TestUtil.generateNode(30303);
+    NodeInfo nodePair2 = TestUtil.generateNode(30304);
     NodeRecord nodeRecord1 = nodePair1.getNodeRecord();
     NodeRecord nodeRecord2 = nodePair2.getNodeRecord();
     NodeTableStorageFactoryImpl nodeTableStorageFactory = new NodeTableStorageFactoryImpl();

--- a/src/test/java/org/ethereum/beacon/discovery/TestUtil.java
+++ b/src/test/java/org/ethereum/beacon/discovery/TestUtil.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery;
 
 import java.util.Random;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.ethereum.beacon.discovery.format.SerializerFactory;
 import org.ethereum.beacon.discovery.mock.IdentitySchemaV4InterpreterMock;
 import org.ethereum.beacon.discovery.schema.IdentitySchemaV4Interpreter;
@@ -27,12 +28,22 @@ public class TestUtil {
 
   /**
    * Generates node on 127.0.0.1 with provided port. Node key is random, but always the same for the
-   * same port. Signature is not valid if verified.
+   * same port. Signature is not validated.
    *
    * @return <code><private key, node record></code>
    */
   public static NodeInfo generateUnverifiedNode(int port) {
-    return generateNode(port, false);
+    return generateNode(port, false, true);
+  }
+
+  /**
+   * Generates node on 127.0.0.1 with provided port. Node key is random, but always the same for the
+   * same port. Validation will fail.
+   *
+   * @return <code><private key, node record></code>
+   */
+  public static NodeInfo generateInvalidNode(int port) {
+    return generateNode(port, true, false);
   }
 
   /**
@@ -40,10 +51,22 @@ public class TestUtil {
    * same port.
    *
    * @param port listen port
-   * @param verification whether to use valid signature
    * @return <code><private key, node record></code>
    */
-  public static NodeInfo generateNode(int port, boolean verification) {
+  public static NodeInfo generateNode(int port) {
+    return generateNode(port, true, true);
+  }
+
+  /**
+   * Generates node on 127.0.0.1 with provided port. Node key is random, but always the same for the
+   * same port.
+   *
+   * @param port listen port
+   * @param verification whether to verify signatures
+   * @param sign whether or not to sign the record
+   * @return <code><private key, node record></code>
+   */
+  private static NodeInfo generateNode(int port, boolean verification, boolean sign) {
     final Random rnd = new Random(SEED);
     for (int i = 0; i < port; ++i) {
       rnd.nextBoolean(); // skip according to input
@@ -60,7 +83,9 @@ public class TestUtil {
             .address(LOCALHOST, port)
             .build();
 
-    nodeRecord.sign(Bytes.wrap(privateKey));
+    if (!sign) {
+      nodeRecord.setSignature(Bytes32.ZERO);
+    }
     return new NodeInfo(Bytes.wrap(privateKey), nodeRecord);
   }
 

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
@@ -81,8 +81,10 @@ class NodesHandlerTest {
   @Test
   public void shouldRejectReceivedRecordsThatAreNotAtCorrectDistance() {
     final NodeInfo nodeInfo = TestUtil.generateNode(9000);
+    final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
     final FindNodeRequestInfo requestInfo =
-        new FindNodeRequestInfo(TaskStatus.SENT, REQUEST_ID, new CompletableFuture<>(), 0, null);
+        new FindNodeRequestInfo(
+            TaskStatus.SENT, REQUEST_ID, new CompletableFuture<>(), distance - 1, null);
     when(session.getRequestId(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
     final List<NodeRecord> records = Collections.singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message =

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
@@ -80,7 +80,7 @@ class NodesHandlerTest {
 
   @Test
   public void shouldRejectReceivedRecordsThatAreNotAtCorrectDistance() {
-    final NodeInfo nodeInfo = TestUtil.generateInvalidNode(9000);
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000);
     final FindNodeRequestInfo requestInfo =
         new FindNodeRequestInfo(TaskStatus.SENT, REQUEST_ID, new CompletableFuture<>(), 0, null);
     when(session.getRequestId(REQUEST_ID)).thenReturn(Optional.of(requestInfo));

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.TestUtil;
+import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
+import org.ethereum.beacon.discovery.message.NodesMessage;
+import org.ethereum.beacon.discovery.pipeline.info.FindNodeRequestInfo;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
+import org.ethereum.beacon.discovery.schema.NodeSession;
+import org.ethereum.beacon.discovery.storage.NodeTable;
+import org.ethereum.beacon.discovery.task.TaskStatus;
+import org.ethereum.beacon.discovery.task.TaskType;
+import org.ethereum.beacon.discovery.util.Functions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NodesHandlerTest {
+
+  private static final Bytes PEER_ID = Bytes.fromHexString("0x1234567890ABCDEF");
+  private static final Bytes REQUEST_ID = Bytes.fromHexString("0x1234");
+  private final NodeSession session = mock(NodeSession.class);
+  private final NodeTable nodeTable = Mockito.mock(NodeTable.class);
+  private final NodesHandler handler = new NodesHandler();
+
+  @BeforeEach
+  public void setUp() {
+    when(session.getNodeTable()).thenReturn(nodeTable);
+    when(session.getNodeId()).thenReturn(PEER_ID);
+  }
+
+  @Test
+  public void shouldAddReceivedRecordsToNodeTable() {
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000);
+    final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
+    final FindNodeRequestInfo requestInfo =
+        new FindNodeRequestInfo(
+            TaskStatus.SENT, REQUEST_ID, new CompletableFuture<>(), distance, null);
+    when(session.getRequestId(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final List<NodeRecord> records = Collections.singletonList(nodeInfo.getNodeRecord());
+    final NodesMessage message =
+        new NodesMessage(REQUEST_ID, records.size(), () -> records, records.size());
+    handler.handle(message, session);
+
+    final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeInfo.getNodeRecord());
+    verify(nodeTable).save(nodeRecordInfo);
+    verify(session).putRecordInBucket(nodeRecordInfo);
+    verify(session).clearRequestId(REQUEST_ID, TaskType.FINDNODE);
+  }
+
+  @Test
+  public void shouldRejectReceivedRecordsThatAreInvalid() {
+    final NodeInfo nodeInfo = TestUtil.generateInvalidNode(9000);
+    final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
+    final FindNodeRequestInfo requestInfo =
+        new FindNodeRequestInfo(
+            TaskStatus.SENT, REQUEST_ID, new CompletableFuture<>(), distance, null);
+    when(session.getRequestId(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final List<NodeRecord> records = Collections.singletonList(nodeInfo.getNodeRecord());
+    final NodesMessage message =
+        new NodesMessage(REQUEST_ID, records.size(), () -> records, records.size());
+    handler.handle(message, session);
+
+    verifyNoInteractions(nodeTable);
+  }
+
+  @Test
+  public void shouldRejectReceivedRecordsThatAreNotAtCorrectDistance() {
+    final NodeInfo nodeInfo = TestUtil.generateInvalidNode(9000);
+    final FindNodeRequestInfo requestInfo =
+        new FindNodeRequestInfo(TaskStatus.SENT, REQUEST_ID, new CompletableFuture<>(), 0, null);
+    when(session.getRequestId(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final List<NodeRecord> records = Collections.singletonList(nodeInfo.getNodeRecord());
+    final NodesMessage message =
+        new NodesMessage(REQUEST_ID, records.size(), () -> records, records.size());
+    handler.handle(message, session);
+
+    verifyNoInteractions(nodeTable);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/schema/NodeRecordInfoTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/NodeRecordInfoTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 class NodeRecordInfoTest {
   @Test
   public void shouldRoundTripViaRlp() {
-    final NodeInfo nodeInfo = TestUtil.generateNode(9000, true);
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000);
     final NodeRecordInfo nodeRecordInfo =
         new NodeRecordInfo(nodeInfo.getNodeRecord(), 4982924L, NodeStatus.SLEEP, 1);
 


### PR DESCRIPTION
## PR Description
To make it more difficult for malicious nodes to pollute our node table, verify that any nodes returned from a find nodes request are at the distance requested.