### PR TITLE
Fix NodeRecordInfo deserialization

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordInfo.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordInfo.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery.schema;
 
 import com.google.common.base.Objects;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.web3j.rlp.RlpDecoder;
@@ -36,12 +37,13 @@ public class NodeRecordInfo {
   }
 
   public static NodeRecordInfo fromRlpBytes(Bytes bytes, NodeRecordFactory nodeRecordFactory) {
-    RlpList internalList = (RlpList) RlpDecoder.decode(bytes.toArray()).getValues().get(0);
+    final Iterator<RlpType> values =
+        ((RlpList) RlpDecoder.decode(bytes.toArray()).getValues().get(0)).getValues().iterator();
     return new NodeRecordInfo(
-        nodeRecordFactory.fromBytes(((RlpString) internalList.getValues().get(0)).getBytes()),
-        ((RlpString) internalList.getValues().get(1)).asPositiveBigInteger().longValue(),
-        NodeStatus.fromNumber(((RlpString) internalList.getValues().get(2)).getBytes()[0]),
-        ((RlpString) internalList.getValues().get(1)).asPositiveBigInteger().intValue());
+        nodeRecordFactory.fromBytes(((RlpString) values.next()).getBytes()),
+        ((RlpString) values.next()).asPositiveBigInteger().longValue(),
+        NodeStatus.fromNumber(((RlpString) values.next()).getBytes()[0]),
+        ((RlpString) values.next()).asPositiveBigInteger().intValue());
   }
 
   public Bytes toRlpBytes() {

--- a/src/test/java/org/ethereum/beacon/discovery/schema/NodeRecordInfoTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/NodeRecordInfoTest.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.TestUtil;
+import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+class NodeRecordInfoTest {
+  @Test
+  public void shouldRoundTripViaRlp() {
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000, true);
+    final NodeRecordInfo nodeRecordInfo = new NodeRecordInfo(
+        nodeInfo.getNodeRecord(),
+        4982924L,
+        NodeStatus.SLEEP,
+        1);
+
+    final Bytes rlp = nodeRecordInfo.toRlpBytes();
+    final NodeRecordInfo result = NodeRecordInfo.fromRlpBytes(
+        rlp,
+        NodeRecordFactory.DEFAULT);
+    assertEquals(nodeRecordInfo, result);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/schema/NodeRecordInfoTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/NodeRecordInfoTest.java
@@ -15,16 +15,11 @@ class NodeRecordInfoTest {
   @Test
   public void shouldRoundTripViaRlp() {
     final NodeInfo nodeInfo = TestUtil.generateNode(9000, true);
-    final NodeRecordInfo nodeRecordInfo = new NodeRecordInfo(
-        nodeInfo.getNodeRecord(),
-        4982924L,
-        NodeStatus.SLEEP,
-        1);
+    final NodeRecordInfo nodeRecordInfo =
+        new NodeRecordInfo(nodeInfo.getNodeRecord(), 4982924L, NodeStatus.SLEEP, 1);
 
     final Bytes rlp = nodeRecordInfo.toRlpBytes();
-    final NodeRecordInfo result = NodeRecordInfo.fromRlpBytes(
-        rlp,
-        NodeRecordFactory.DEFAULT);
+    final NodeRecordInfo result = NodeRecordInfo.fromRlpBytes(rlp, NodeRecordFactory.DEFAULT);
     assertEquals(nodeRecordInfo, result);
   }
 }


### PR DESCRIPTION
## PR Description
`NodeRecordInfo` was incorrectly reading the `lastRetry` (time) value as the `retry` value (count of failed attempts) when deserialising.  Records are serialized and deserialised whenever they are stored to the node table.  As a result, any node in the node table with a non-zero `lastRetry` time would become eligible for deletion when it was reloaded and potentially removed from the node table.