### PR TITLE
Reduce log level for errors handling data from external sources

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/AuthHeaderMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/AuthHeaderMessagePacketHandler.java
@@ -105,7 +105,7 @@ public class AuthHeaderMessagePacketHandler implements EnvelopeHandler {
         session.getNodeTable().save(NodeRecordInfo.createDefault(nodeRecord));
       }
     } catch (Exception ex) {
-      logger.error(
+      logger.debug(
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               packet, session.getNodeRecord(), session.getStatus()),

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
@@ -47,7 +47,7 @@ public class MessagePacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               packet, session.getNodeRecord(), session.getStatus());
-      logger.error(error, ex);
+      logger.debug(error, ex);
       envelope.remove(Field.PACKET_MESSAGE);
       envelope.put(Field.BAD_PACKET, packet);
       return;

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NotExpectedIncomingPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NotExpectedIncomingPacketHandler.java
@@ -76,7 +76,7 @@ public class NotExpectedIncomingPacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               unknownPacket, session.getNodeRecord(), session.getStatus());
-      logger.error(error, ex);
+      logger.debug(error, ex);
       envelope.put(Field.BAD_PACKET, envelope.get(Field.PACKET_UNKNOWN));
       envelope.put(Field.BAD_EXCEPTION, ex);
       envelope.remove(Field.PACKET_UNKNOWN);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTypeByStatus.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTypeByStatus.java
@@ -73,7 +73,7 @@ public class UnknownPacketTypeByStatus implements EnvelopeHandler {
         {
           String error =
               String.format(
-                  "Not expected status:%s from node: %s",
+                  "Not expected status: %s from node: %s",
                   session.getStatus(), session.getNodeRecord());
           logger.error(error);
           throw new RuntimeException(error);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -126,7 +126,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               packet, nodeRecord, session.getStatus());
-      logger.error(error, ex);
+      logger.debug(error, ex);
       envelope.remove(Field.PACKET_WHOAREYOU);
       session.cancelAllRequests("Bad WHOAREYOU received from node");
       return;

--- a/src/main/java/org/ethereum/beacon/discovery/processor/MessageProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/processor/MessageProcessor.java
@@ -38,7 +38,7 @@ public class MessageProcessor {
           String.format(
               "Message %s with identity %s received in session %s is not supported",
               message, protocol, session);
-      logger.error(error);
+      logger.debug(error);
       throw new RuntimeException(error);
     }
     messageHandler.handleMessage(message, session);


### PR DESCRIPTION
## PR Description
We expect external peers to send us rubbish sometimes so only log those problems at debug level instead of error.