### PR TITLE
Reuse a single thread for scheduling expirations

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -33,6 +33,7 @@ import org.ethereum.beacon.discovery.pipeline.handler.UnknownPacketTypeByStatus;
 import org.ethereum.beacon.discovery.pipeline.handler.WhoAreYouAttempt;
 import org.ethereum.beacon.discovery.pipeline.handler.WhoAreYouPacketHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.WhoAreYouSessionResolver;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
@@ -61,7 +62,8 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
       LocalNodeRecordStore localNodeRecordStore,
       Bytes homeNodePrivateKey,
       NodeRecordFactory nodeRecordFactory,
-      Scheduler taskScheduler) {
+      Scheduler taskScheduler,
+      ExpirationSchedulerFactory expirationSchedulerFactory) {
     this.localNodeRecordStore = localNodeRecordStore;
     final NodeRecord homeNodeRecord = localNodeRecordStore.getLocalNodeRecord();
     AuthTagRepository authTagRepo = new AuthTagRepository();
@@ -80,7 +82,8 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
             nodeBucketStorage,
             authTagRepo,
             nodeTable,
-            outgoingPipeline);
+            outgoingPipeline,
+            expirationSchedulerFactory);
     incomingPipeline
         .addHandler(new IncomingDataPacker())
         .addHandler(new WhoAreYouAttempt(homeNodeRecord.getNodeId()))

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystem.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystem.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.storage.NodeTable;
@@ -18,16 +19,19 @@ public class DiscoverySystem {
   private static final Logger LOG = LogManager.getLogger();
   private final DiscoveryManager discoveryManager;
   private final DiscoveryTaskManager taskManager;
+  private final ExpirationSchedulerFactory expirationSchedulerFactory;
   private final NodeTable nodeTable;
   private final List<NodeRecord> bootnodes;
 
   DiscoverySystem(
       final DiscoveryManager discoveryManager,
       final DiscoveryTaskManager taskManager,
+      final ExpirationSchedulerFactory expirationSchedulerFactory,
       final NodeTable nodeTable,
       final List<NodeRecord> bootnodes) {
     this.discoveryManager = discoveryManager;
     this.taskManager = taskManager;
+    this.expirationSchedulerFactory = expirationSchedulerFactory;
     this.nodeTable = nodeTable;
     this.bootnodes = bootnodes;
   }
@@ -51,6 +55,7 @@ public class DiscoverySystem {
   public void stop() {
     taskManager.stop();
     discoveryManager.stop();
+    expirationSchedulerFactory.stop();
   }
 
   public NodeRecord getLocalNodeRecord() {

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -104,7 +104,7 @@ public class DiscoverySystemBuilder {
             localNodeRecordStore,
             privateKey,
             nodeRecordFactory,
-            schedulers.newSingleThreadDaemon("client-" + clientNumber),
+            schedulers.newSingleThreadDaemon("discovery-client-" + clientNumber),
             expirationSchedulerFactory);
 
     final DiscoveryTaskManager discoveryTaskManager =
@@ -113,7 +113,7 @@ public class DiscoverySystemBuilder {
             nodeTable,
             nodeBucketStorage,
             localNodeRecord,
-            schedulers.newSingleThreadDaemon("tasks-" + clientNumber),
+            schedulers.newSingleThreadDaemon("discovery-tasks-" + clientNumber),
             true,
             true,
             expirationSchedulerFactory);

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -6,13 +6,16 @@ package org.ethereum.beacon.discovery;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.database.Database;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Schedulers;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
@@ -90,6 +93,10 @@ public class DiscoverySystemBuilder {
     final int clientNumber = COUNTER.incrementAndGet();
     final LocalNodeRecordStore localNodeRecordStore =
         new LocalNodeRecordStore(localNodeRecord, privateKey);
+    final ExpirationSchedulerFactory expirationSchedulerFactory =
+        new ExpirationSchedulerFactory(
+            Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("discovery-expiration-%d").build()));
     final DiscoveryManager discoveryManager =
         new DiscoveryManagerImpl(
             nodeTable,
@@ -97,7 +104,8 @@ public class DiscoverySystemBuilder {
             localNodeRecordStore,
             privateKey,
             nodeRecordFactory,
-            schedulers.newSingleThreadDaemon("client-" + clientNumber));
+            schedulers.newSingleThreadDaemon("client-" + clientNumber),
+            expirationSchedulerFactory);
 
     final DiscoveryTaskManager discoveryTaskManager =
         new DiscoveryTaskManager(
@@ -107,7 +115,9 @@ public class DiscoverySystemBuilder {
             localNodeRecord,
             schedulers.newSingleThreadDaemon("tasks-" + clientNumber),
             true,
-            true);
-    return new DiscoverySystem(discoveryManager, discoveryTaskManager, nodeTable, bootnodes);
+            true,
+            expirationSchedulerFactory);
+    return new DiscoverySystem(
+        discoveryManager, discoveryTaskManager, expirationSchedulerFactory, nodeTable, bootnodes);
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeIdToSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeIdToSession.java
@@ -36,7 +36,8 @@ import org.ethereum.beacon.discovery.storage.NodeTable;
  * should be in request field and stores it in {@link Field#SESSION} field.
  */
 public class NodeIdToSession implements EnvelopeHandler {
-  private static final int CLEANUP_DELAY_SECONDS = 180;
+  private static final int SESSION_CLEANUP_DELAY_SECONDS = 180;
+  private static final int REQUEST_CLEANUP_DELAY_SECONDS = 60;
   private static final Logger logger = LogManager.getLogger(NodeIdToSession.class);
   private final LocalNodeRecordStore localNodeRecordStore;
   private final Bytes staticNodeKey;
@@ -46,7 +47,7 @@ public class NodeIdToSession implements EnvelopeHandler {
   private final NodeTable nodeTable;
   private final Pipeline outgoingPipeline;
   private final ExpirationScheduler<SessionKey> sessionExpirationScheduler;
-  private final ExpirationSchedulerFactory expirationSchedulerFactory;
+  private final ExpirationScheduler<Bytes> requestExpirationScheduler;
 
   public NodeIdToSession(
       LocalNodeRecordStore localNodeRecordStore,
@@ -63,8 +64,9 @@ public class NodeIdToSession implements EnvelopeHandler {
     this.nodeTable = nodeTable;
     this.outgoingPipeline = outgoingPipeline;
     this.sessionExpirationScheduler =
-        expirationSchedulerFactory.create(CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
-    this.expirationSchedulerFactory = expirationSchedulerFactory;
+        expirationSchedulerFactory.create(SESSION_CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
+    this.requestExpirationScheduler =
+        expirationSchedulerFactory.create(REQUEST_CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
   }
 
   @Override
@@ -114,7 +116,7 @@ public class NodeIdToSession implements EnvelopeHandler {
         authTagRepo,
         outgoingPipeline::push,
         random,
-        expirationSchedulerFactory);
+        requestExpirationScheduler);
   }
 
   private InetSocketAddress getRemoteSocketAddress(final Envelope envelope) {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeIdToSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeIdToSession.java
@@ -22,6 +22,7 @@ import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.pipeline.Pipeline;
 import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeSession;
@@ -44,8 +45,8 @@ public class NodeIdToSession implements EnvelopeHandler {
   private final Map<SessionKey, NodeSession> recentSessions = new ConcurrentHashMap<>();
   private final NodeTable nodeTable;
   private final Pipeline outgoingPipeline;
-  private ExpirationScheduler<SessionKey> sessionExpirationScheduler =
-      new ExpirationScheduler<>(CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
+  private final ExpirationScheduler<SessionKey> sessionExpirationScheduler;
+  private final ExpirationSchedulerFactory expirationSchedulerFactory;
 
   public NodeIdToSession(
       LocalNodeRecordStore localNodeRecordStore,
@@ -53,13 +54,17 @@ public class NodeIdToSession implements EnvelopeHandler {
       NodeBucketStorage nodeBucketStorage,
       AuthTagRepository authTagRepo,
       NodeTable nodeTable,
-      Pipeline outgoingPipeline) {
+      Pipeline outgoingPipeline,
+      ExpirationSchedulerFactory expirationSchedulerFactory) {
     this.localNodeRecordStore = localNodeRecordStore;
     this.staticNodeKey = staticNodeKey;
     this.nodeBucketStorage = nodeBucketStorage;
     this.authTagRepo = authTagRepo;
     this.nodeTable = nodeTable;
     this.outgoingPipeline = outgoingPipeline;
+    this.sessionExpirationScheduler =
+        expirationSchedulerFactory.create(CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
+    this.expirationSchedulerFactory = expirationSchedulerFactory;
   }
 
   @Override
@@ -108,7 +113,8 @@ public class NodeIdToSession implements EnvelopeHandler {
         nodeBucketStorage,
         authTagRepo,
         outgoingPipeline::push,
-        random);
+        random,
+        expirationSchedulerFactory);
   }
 
   private InetSocketAddress getRemoteSocketAddress(final Envelope envelope) {

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/ExpirationScheduler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/ExpirationScheduler.java
@@ -6,7 +6,6 @@ package org.ethereum.beacon.discovery.scheduler;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -16,16 +15,17 @@ import java.util.concurrent.TimeUnit;
  * in map again, old task is cancelled and removed. Task are equalled by the <Key>
  */
 public class ExpirationScheduler<Key> {
-  private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService scheduler;
   private final long delay;
   private final TimeUnit timeUnit;
 
   @SuppressWarnings({"rawtypes"})
   private Map<Key, ScheduledFuture> expirationTasks = new ConcurrentHashMap<>();
 
-  public ExpirationScheduler(long delay, TimeUnit timeUnit) {
+  ExpirationScheduler(long delay, TimeUnit timeUnit, final ScheduledExecutorService scheduler) {
     this.delay = delay;
     this.timeUnit = timeUnit;
+    this.scheduler = scheduler;
   }
 
   /**

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/ExpirationSchedulerFactory.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/ExpirationSchedulerFactory.java
@@ -1,0 +1,20 @@
+package org.ethereum.beacon.discovery.scheduler;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ExpirationSchedulerFactory {
+  private final ScheduledExecutorService scheduler;
+
+  public ExpirationSchedulerFactory(final ScheduledExecutorService scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  public <Key> ExpirationScheduler<Key> create(long delay, TimeUnit timeUnit) {
+    return new ExpirationScheduler<>(delay, timeUnit, scheduler);
+  }
+
+  public void stop() {
+    scheduler.shutdownNow();
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/ExpirationSchedulerFactory.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/ExpirationSchedulerFactory.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.ethereum.beacon.discovery.scheduler;
 
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -16,7 +16,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,7 +26,6 @@ import org.ethereum.beacon.discovery.packet.Packet;
 import org.ethereum.beacon.discovery.pipeline.info.RequestInfo;
 import org.ethereum.beacon.discovery.pipeline.info.RequestInfoFactory;
 import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
-import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.storage.AuthTagRepository;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 import org.ethereum.beacon.discovery.storage.NodeBucket;
@@ -45,7 +43,6 @@ public class NodeSession {
   public static final int NONCE_SIZE = 12;
   public static final int REQUEST_ID_SIZE = 8;
   private static final Logger logger = LogManager.getLogger(NodeSession.class);
-  private static final int CLEANUP_DELAY_SECONDS = 60;
   private final Bytes homeNodeId;
   private final LocalNodeRecordStore localNodeRecordStore;
   private final AuthTagRepository authTagRepo;
@@ -75,7 +72,7 @@ public class NodeSession {
       AuthTagRepository authTagRepo,
       Consumer<NetworkParcel> outgoingPipeline,
       Random rnd,
-      ExpirationSchedulerFactory expirationSchedulerFactory) {
+      ExpirationScheduler<Bytes> requestExpirationScheduler) {
     this.nodeId = nodeId;
     this.nodeRecord = nodeRecord;
     this.remoteAddress = remoteAddress;
@@ -87,8 +84,7 @@ public class NodeSession {
     this.homeNodeId = localNodeRecordStore.getLocalNodeRecord().getNodeId();
     this.outgoingPipeline = outgoingPipeline;
     this.rnd = rnd;
-    this.requestExpirationScheduler =
-        expirationSchedulerFactory.create(CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
+    this.requestExpirationScheduler = requestExpirationScheduler;
   }
 
   public Bytes getNodeId() {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -27,6 +27,7 @@ import org.ethereum.beacon.discovery.packet.Packet;
 import org.ethereum.beacon.discovery.pipeline.info.RequestInfo;
 import org.ethereum.beacon.discovery.pipeline.info.RequestInfoFactory;
 import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.storage.AuthTagRepository;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 import org.ethereum.beacon.discovery.storage.NodeBucket;
@@ -59,10 +60,9 @@ public class NodeSession {
   private Bytes idNonce;
   private Bytes initiatorKey;
   private Bytes recipientKey;
-  private Map<Bytes, RequestInfo> requestIdStatuses = new ConcurrentHashMap<>();
-  private ExpirationScheduler<Bytes> requestExpirationScheduler =
-      new ExpirationScheduler<>(CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
-  private Bytes staticNodeKey;
+  private final Map<Bytes, RequestInfo> requestIdStatuses = new ConcurrentHashMap<>();
+  private final ExpirationScheduler<Bytes> requestExpirationScheduler;
+  private final Bytes staticNodeKey;
 
   public NodeSession(
       Bytes nodeId,
@@ -74,7 +74,8 @@ public class NodeSession {
       NodeBucketStorage nodeBucketStorage,
       AuthTagRepository authTagRepo,
       Consumer<NetworkParcel> outgoingPipeline,
-      Random rnd) {
+      Random rnd,
+      ExpirationSchedulerFactory expirationSchedulerFactory) {
     this.nodeId = nodeId;
     this.nodeRecord = nodeRecord;
     this.remoteAddress = remoteAddress;
@@ -86,6 +87,8 @@ public class NodeSession {
     this.homeNodeId = localNodeRecordStore.getLocalNodeRecord().getNodeId();
     this.outgoingPipeline = outgoingPipeline;
     this.rnd = rnd;
+    this.requestExpirationScheduler =
+        expirationSchedulerFactory.create(CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
   }
 
   public Bytes getNodeId() {

--- a/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.ethereum.beacon.discovery.DiscoveryManager;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
@@ -123,16 +124,24 @@ public class DiscoveryTaskManager {
       Scheduler scheduler,
       boolean resetDead,
       boolean removeDead,
+      ExpirationSchedulerFactory expirationSchedulerFactory,
       Consumer<NodeRecord>... nodeRecordUpdatesConsumers) {
     this.scheduler = scheduler;
     this.nodeTable = nodeTable;
     this.nodeBucketStorage = nodeBucketStorage;
     this.homeNodeId = homeNode.getNodeId();
     this.liveCheckTasks =
-        new LiveCheckTasks(discoveryManager, scheduler, Duration.ofSeconds(RETRY_TIMEOUT_SECONDS));
+        new LiveCheckTasks(
+            discoveryManager,
+            scheduler,
+            expirationSchedulerFactory,
+            Duration.ofSeconds(RETRY_TIMEOUT_SECONDS));
     this.recursiveLookupTasks =
         new RecursiveLookupTasks(
-            discoveryManager, scheduler, Duration.ofSeconds(RETRY_TIMEOUT_SECONDS));
+            discoveryManager,
+            scheduler,
+            expirationSchedulerFactory,
+            Duration.ofSeconds(RETRY_TIMEOUT_SECONDS));
     this.resetDead = resetDead;
     this.removeDead = removeDead;
     this.nodeRecordUpdatesConsumers = nodeRecordUpdatesConsumers;

--- a/src/main/java/org/ethereum/beacon/discovery/task/LiveCheckTasks.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/LiveCheckTasks.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.DiscoveryManager;
 import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 
@@ -30,11 +31,15 @@ public class LiveCheckTasks {
   private final Set<Bytes> currentTasks = Sets.newConcurrentHashSet();
   private final ExpirationScheduler<Bytes> taskTimeouts;
 
-  public LiveCheckTasks(DiscoveryManager discoveryManager, Scheduler scheduler, Duration timeout) {
+  public LiveCheckTasks(
+      DiscoveryManager discoveryManager,
+      Scheduler scheduler,
+      ExpirationSchedulerFactory expirationSchedulerFactory,
+      Duration timeout) {
     this.discoveryManager = discoveryManager;
     this.scheduler = scheduler;
     this.taskTimeouts =
-        new ExpirationScheduler<>(timeout.get(ChronoUnit.SECONDS), TimeUnit.SECONDS);
+        expirationSchedulerFactory.create(timeout.get(ChronoUnit.SECONDS), TimeUnit.SECONDS);
   }
 
   public void add(NodeRecordInfo nodeRecordInfo, Runnable successCallback, Runnable failCallback) {

--- a/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTasks.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTasks.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.DiscoveryManager;
 import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 
@@ -28,11 +29,14 @@ public class RecursiveLookupTasks {
   private final ExpirationScheduler<Bytes> taskTimeouts;
 
   public RecursiveLookupTasks(
-      DiscoveryManager discoveryManager, Scheduler scheduler, Duration timeout) {
+      DiscoveryManager discoveryManager,
+      Scheduler scheduler,
+      ExpirationSchedulerFactory expirationSchedulerFactory,
+      Duration timeout) {
     this.discoveryManager = discoveryManager;
     this.scheduler = scheduler;
     this.taskTimeouts =
-        new ExpirationScheduler<>(timeout.get(ChronoUnit.SECONDS), TimeUnit.SECONDS);
+        expirationSchedulerFactory.create(timeout.get(ChronoUnit.SECONDS), TimeUnit.SECONDS);
   }
 
   public CompletableFuture<Void> add(NodeRecord nodeRecord, int distance) {

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -10,12 +10,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
 import org.ethereum.beacon.discovery.database.Database;
 import org.ethereum.beacon.discovery.packet.AuthHeaderMessagePacket;
 import org.ethereum.beacon.discovery.packet.RandomPacket;
 import org.ethereum.beacon.discovery.packet.UnknownPacket;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Schedulers;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
@@ -75,7 +77,8 @@ public class DiscoveryInteropTest {
             new LocalNodeRecordStore(nodeRecord1, nodePair1.getPrivateKey()),
             nodePair1.getPrivateKey(),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("tasks-1"));
+            Schedulers.createDefault().newSingleThreadDaemon("tasks-1"),
+            new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor()));
 
     // 3) Expect standard 1 => 2 dialog
     CountDownLatch randomSent1to2 = new CountDownLatch(1);

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
 import org.ethereum.beacon.discovery.database.Database;
@@ -20,6 +21,7 @@ import org.ethereum.beacon.discovery.packet.MessagePacket;
 import org.ethereum.beacon.discovery.packet.RandomPacket;
 import org.ethereum.beacon.discovery.packet.UnknownPacket;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Schedulers;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
@@ -69,6 +71,8 @@ public class DiscoveryNetworkTest {
                 });
     NodeBucketStorage nodeBucketStorage2 =
         nodeTableStorageFactory.createBucketStorage(database2, TEST_SERIALIZER, nodeRecord2);
+    ExpirationSchedulerFactory expirationSchedulerFactory =
+        new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor());
     DiscoveryManagerImpl discoveryManager1 =
         new DiscoveryManagerImpl(
             nodeTableStorage1.get(),
@@ -76,7 +80,8 @@ public class DiscoveryNetworkTest {
             new LocalNodeRecordStore(nodeRecord1, nodePair1.getPrivateKey()),
             nodePair1.getPrivateKey(),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("tasks-1"));
+            Schedulers.createDefault().newSingleThreadDaemon("tasks-1"),
+            expirationSchedulerFactory);
     DiscoveryManagerImpl discoveryManager2 =
         new DiscoveryManagerImpl(
             nodeTableStorage2.get(),
@@ -84,7 +89,8 @@ public class DiscoveryNetworkTest {
             new LocalNodeRecordStore(nodeRecord2, nodePair2.getPrivateKey()),
             nodePair2.getPrivateKey(),
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            Schedulers.createDefault().newSingleThreadDaemon("tasks-2"));
+            Schedulers.createDefault().newSingleThreadDaemon("tasks-2"),
+            expirationSchedulerFactory);
 
     // 3) Expect standard 1 => 2 dialog
     CountDownLatch randomSent1to2 = new CountDownLatch(1);

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -40,6 +40,7 @@ import org.ethereum.beacon.discovery.pipeline.handler.AuthHeaderMessagePacketHan
 import org.ethereum.beacon.discovery.pipeline.handler.MessageHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.MessagePacketHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.WhoAreYouPacketHandler;
+import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
 import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.scheduler.Schedulers;
@@ -113,6 +114,8 @@ public class HandshakeHandlersTest {
         new LocalNodeRecordStore(nodeRecord1, nodePair1.getPrivateKey());
     final ExpirationSchedulerFactory expirationSchedulerFactory =
         new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor());
+    final ExpirationScheduler<Bytes> reqeustExpirationScheduler =
+        expirationSchedulerFactory.create(60, TimeUnit.SECONDS);
     NodeSession nodeSessionAt1For2 =
         new NodeSession(
             nodeRecord2.getNodeId(),
@@ -125,7 +128,7 @@ public class HandshakeHandlersTest {
             authTagRepository1,
             outgoingMessages1to2,
             rnd,
-            expirationSchedulerFactory);
+            reqeustExpirationScheduler);
     final Consumer<NetworkParcel> outgoingMessages2to1 =
         packet -> {
           // do nothing, we don't need to test it here
@@ -142,7 +145,7 @@ public class HandshakeHandlersTest {
             new AuthTagRepository(),
             outgoingMessages2to1,
             rnd,
-            expirationSchedulerFactory);
+            reqeustExpirationScheduler);
 
     Scheduler taskScheduler = Schedulers.createDefault().events();
     Pipeline outgoingPipeline = new PipelineImpl().build();

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -39,6 +40,7 @@ import org.ethereum.beacon.discovery.pipeline.handler.AuthHeaderMessagePacketHan
 import org.ethereum.beacon.discovery.pipeline.handler.MessageHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.MessagePacketHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.WhoAreYouPacketHandler;
+import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.scheduler.Schedulers;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
@@ -109,6 +111,8 @@ public class HandshakeHandlersTest {
     AuthTagRepository authTagRepository1 = new AuthTagRepository();
     final LocalNodeRecordStore localNodeRecordStoreAt1 =
         new LocalNodeRecordStore(nodeRecord1, nodePair1.getPrivateKey());
+    final ExpirationSchedulerFactory expirationSchedulerFactory =
+        new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor());
     NodeSession nodeSessionAt1For2 =
         new NodeSession(
             nodeRecord2.getNodeId(),
@@ -120,7 +124,8 @@ public class HandshakeHandlersTest {
             nodeBucketStorage1,
             authTagRepository1,
             outgoingMessages1to2,
-            rnd);
+            rnd,
+            expirationSchedulerFactory);
     final Consumer<NetworkParcel> outgoingMessages2to1 =
         packet -> {
           // do nothing, we don't need to test it here
@@ -136,7 +141,8 @@ public class HandshakeHandlersTest {
             nodeBucketStorage2,
             new AuthTagRepository(),
             outgoingMessages2to1,
-            rnd);
+            rnd,
+            expirationSchedulerFactory);
 
     Scheduler taskScheduler = Schedulers.createDefault().events();
     Pipeline outgoingPipeline = new PipelineImpl().build();


### PR DESCRIPTION
## PR Description
Fixes a thread leak where a new scheduled executor was created for every `NodeSession` by reusing a single `ScheduledExecutor` across all `ExpirationScheduler` instances.