### PR TITLE
Parse unknown fields as Bytes

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreterV4.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreterV4.java
@@ -13,6 +13,9 @@ import org.web3j.rlp.RlpString;
 import org.web3j.rlp.RlpType;
 
 public class EnrFieldInterpreterV4 implements EnrFieldInterpreter {
+
+  public static final Function<RlpString, Object> DEFAULT_DECODER =
+      rlp -> Bytes.wrap(rlp.getBytes());
   public static EnrFieldInterpreterV4 DEFAULT = new EnrFieldInterpreterV4();
 
   private Map<String, Function<RlpString, Object>> fieldDecoders = new HashMap<>();
@@ -32,10 +35,7 @@ public class EnrFieldInterpreterV4 implements EnrFieldInterpreter {
 
   @Override
   public Object decode(String key, RlpString rlpString) {
-    Function<RlpString, Object> fieldDecoder = fieldDecoders.get(key);
-    if (fieldDecoder == null) {
-      throw new RuntimeException(String.format("No decoder found for field `%s`", key));
-    }
+    Function<RlpString, Object> fieldDecoder = fieldDecoders.getOrDefault(key, DEFAULT_DECODER);
     return fieldDecoder.apply(rlpString);
   }
 

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -4,6 +4,7 @@
 
 package org.ethereum.beacon.discovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.ethereum.beacon.discovery.TestUtil.SEED;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,6 +72,29 @@ public class NodeRecordTest {
     assertEquals(expectedSeqNumber, nodeRecordRestored.getSeq());
     assertEquals(expectedPublicKey, nodeRecordRestored.get(EnrField.PKEY_SECP256K1));
     assertEquals(expectedSignature, nodeRecordRestored.getSignature());
+  }
+
+  @Test
+  public void testEnrWithCustomFieldsDecodes() {
+    final int port = 30303;
+    final Bytes ip = Bytes.fromHexString("0x7F000001");
+    final Bytes nodeId =
+        Bytes.fromHexString("a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7");
+    final Bytes privateKey =
+        Bytes.fromHexString("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    final NodeRecord record =
+        NODE_RECORD_FACTORY.createFromValues(
+            UInt64.ONE,
+            new EnrField(EnrField.ID, IdentitySchema.V4),
+            new EnrField(EnrField.PKEY_SECP256K1, nodeId),
+            new EnrField(EnrField.IP_V4, ip),
+            new EnrField(EnrField.TCP, port),
+            new EnrField("foo", Bytes.fromHexString("0x1234")));
+    record.sign(privateKey);
+
+    final String serialized = record.asBase64();
+    final NodeRecord result = NODE_RECORD_FACTORY.fromBase64(serialized);
+    assertThat(result).isEqualTo(record);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Fixes ENR parsing so that fields which are unknown to the client are not considered invalid.  They are instead simply parsed as `Bytes`.