### PR TITLE
Separate listen and advertised IP

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -7,8 +7,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -32,6 +34,7 @@ import org.ethereum.beacon.discovery.task.DiscoveryTaskManager;
 public class DiscoverySystemBuilder {
   private static final AtomicInteger COUNTER = new AtomicInteger();
   private List<NodeRecord> bootnodes = Collections.emptyList();
+  private Optional<InetSocketAddress> listenAddress = Optional.empty();
   private NodeRecord localNodeRecord;
   private Bytes privateKey;
   private final NodeRecordFactory nodeRecordFactory = NodeRecordFactory.DEFAULT;
@@ -40,6 +43,11 @@ public class DiscoverySystemBuilder {
 
   public DiscoverySystemBuilder localNodeRecord(final NodeRecord localNodeRecord) {
     this.localNodeRecord = localNodeRecord;
+    return this;
+  }
+
+  public DiscoverySystemBuilder listen(final String listenAddress, final int listenPort) {
+    this.listenAddress = Optional.of(new InetSocketAddress(listenAddress, listenPort));
     return this;
   }
 
@@ -99,6 +107,7 @@ public class DiscoverySystemBuilder {
                 new ThreadFactoryBuilder().setNameFormat("discovery-expiration-%d").build()));
     final DiscoveryManager discoveryManager =
         new DiscoveryManagerImpl(
+            listenAddress,
             nodeTable,
             nodeBucketStorage,
             localNodeRecordStore,

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -9,6 +9,7 @@ import static org.ethereum.beacon.discovery.TestUtil.TEST_SERIALIZER;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +73,7 @@ public class DiscoveryInteropTest {
         nodeTableStorageFactory.createBucketStorage(database1, TEST_SERIALIZER, nodeRecord1);
     DiscoveryManagerImpl discoveryManager1 =
         new DiscoveryManagerImpl(
+            Optional.empty(),
             nodeTableStorage1.get(),
             nodeBucketStorage1,
             new LocalNodeRecordStore(nodeRecord1, nodePair1.getPrivateKey()),

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +76,7 @@ public class DiscoveryNetworkTest {
         new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor());
     DiscoveryManagerImpl discoveryManager1 =
         new DiscoveryManagerImpl(
+            Optional.empty(),
             nodeTableStorage1.get(),
             nodeBucketStorage1,
             new LocalNodeRecordStore(nodeRecord1, nodePair1.getPrivateKey()),
@@ -84,6 +86,7 @@ public class DiscoveryNetworkTest {
             expirationSchedulerFactory);
     DiscoveryManagerImpl discoveryManager2 =
         new DiscoveryManagerImpl(
+            Optional.empty(),
             nodeTableStorage2.get(),
             nodeBucketStorage2,
             new LocalNodeRecordStore(nodeRecord2, nodePair2.getPrivateKey()),


### PR DESCRIPTION
## PR Description
Support listening on an IP and port that is different to the IP and port in the local ENR record. This is required when the listen IP is and any address like `0.0.0.0` or when NAT is in use and the external IP and port differ from the internal ones.