### PR TITLE
Fix synchronization in NodeBucket

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucket.java
@@ -5,7 +5,6 @@
 package org.ethereum.beacon.discovery.storage;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -76,12 +75,8 @@ public class NodeBucket {
     return false;
   }
 
-  public boolean contains(NodeRecordInfo nodeRecordInfo) {
+  public synchronized boolean contains(NodeRecordInfo nodeRecordInfo) {
     return bucket.contains(nodeRecordInfo);
-  }
-
-  public void putAll(Collection<NodeRecordInfo> nodeRecords) {
-    nodeRecords.forEach(this::put);
   }
 
   public synchronized Bytes toRlpBytes() {
@@ -100,7 +95,7 @@ public class NodeBucket {
     return bucket.size();
   }
 
-  public List<NodeRecordInfo> getNodeRecords() {
+  public synchronized List<NodeRecordInfo> getNodeRecords() {
     return new ArrayList<>(bucket);
   }
 }


### PR DESCRIPTION
## PR Description
Previously writes were synchronized but reads were not.

That doesn't satisfy the thread safety requirements of TreeSet which could lead to random exceptions, but also meant that the number of records returned by getNodeRecord could exceed the 16 node limit if nodes were added while we were iterating to make a copy.

## Fixed Issue(s)
fixes https://github.com/PegaSysEng/teku/issues/2095
