### PR TITLE
Handle unknown messages with less than 32 bytes correctly

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/packet/UnknownPacket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/packet/UnknownPacket.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery.packet;
 
 import com.google.common.base.Preconditions;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.type.Hashes;
 
@@ -46,10 +47,15 @@ public class UnknownPacket extends AbstractPacket {
   // The recipient can recover the sender's ID by performing the same calculation in reverse.
   //
   // src-node-id      = xor(sha256(dest-node-id), tag)
-  public Bytes getSourceNodeId(Bytes destNodeId) {
+  public Optional<Bytes> getSourceNodeId(Bytes destNodeId) {
     Preconditions.checkArgument(!isWhoAreYouPacket(destNodeId));
-    Bytes xorTag = getBytes().slice(0, START_MAGIC_LENGTH);
-    return Hashes.sha256(destNodeId).xor(xorTag);
+
+    final Bytes bytes = getBytes();
+    if (bytes.size() < START_MAGIC_LENGTH) {
+      return Optional.empty();
+    }
+    Bytes xorTag = bytes.slice(0, START_MAGIC_LENGTH);
+    return Optional.of(Hashes.sha256(destNodeId).xor(xorTag));
   }
 
   public void verify() {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
@@ -45,8 +45,13 @@ public class UnknownPacketTagToSender implements EnvelopeHandler {
     if (!envelope.contains(Field.PACKET_UNKNOWN)) {
       return;
     }
-    UnknownPacket unknownPacket = (UnknownPacket) envelope.get(Field.PACKET_UNKNOWN);
-    Bytes fromNodeId = unknownPacket.getSourceNodeId(homeNodeId);
-    envelope.put(Field.SESSION_LOOKUP, new SessionLookup(fromNodeId));
+    ((UnknownPacket) envelope.get(Field.PACKET_UNKNOWN))
+        .getSourceNodeId(homeNodeId)
+        .ifPresentOrElse(
+            fromNodeId -> envelope.put(Field.SESSION_LOOKUP, new SessionLookup(fromNodeId)),
+            () -> {
+              envelope.put(Field.BAD_PACKET, envelope.get(Field.PACKET_UNKNOWN));
+              envelope.remove(Field.PACKET_UNKNOWN);
+            });
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/packet/UnknownPacketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/packet/UnknownPacketTest.java
@@ -1,0 +1,28 @@
+package org.ethereum.beacon.discovery.packet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.ethereum.beacon.discovery.type.Hashes;
+import org.junit.jupiter.api.Test;
+
+class UnknownPacketTest {
+  @Test
+  void getSourceNodeId_shouldReturnEmptyWhenPacketIsTooShort() {
+    final UnknownPacket unknownPacket = new UnknownPacket(Bytes.of(1, 2, 3));
+    final Bytes32 destNodeId = Bytes32.ZERO;
+    assertThat(unknownPacket.getSourceNodeId(destNodeId)).isEmpty();
+  }
+
+  @Test
+  void getSourceNodeId_shouldExtractSourceNodeId() {
+    final Bytes messageData = Bytes.wrap(new byte[64]);
+    final UnknownPacket unknownPacket = new UnknownPacket(messageData);
+    final Bytes32 destNodeId = Bytes32.ZERO;
+
+    // Should only use first 32 bytes of message data
+    final Bytes expectedSourceId = Hashes.sha256(destNodeId).xor(messageData.slice(0, 32));
+    assertThat(unknownPacket.getSourceNodeId(destNodeId)).contains(expectedSourceId);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/packet/UnknownPacketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/packet/UnknownPacketTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.ethereum.beacon.discovery.packet;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## PR Description
Check that the message is at least 32 bytes long before trying to extract the source node ID from the first 32 bytes.

## Fixed Issue(s)
Fix for https://github.com/PegaSysEng/teku/issues/2509 once it's pulled through to Teku.