### PR TITLE
Use version with git hash in it rather than -SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ bintray {
   publications = ['mavenJava']
   override = version.endsWith('SNAPSHOT')
 
-  publish = true
+  publish = false
 
   pkg {
     repo = 'pegasys-repo'
@@ -201,7 +201,7 @@ bintray {
     vcsUrl = 'https://github.com/PegaSysEng/discovery.git'
 
     version {
-      name = project.version
+      name = calculateVersion()
       released = new Date()
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ bintray {
   publications = ['mavenJava']
   override = version.endsWith('SNAPSHOT')
 
-  publish = false
+  publish = true
 
   pkg {
     repo = 'pegasys-repo'

--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,7 @@ bintray {
     vcsUrl = 'https://github.com/PegaSysEng/discovery.git'
 
     version {
-      name = calculateVersion()
+      name = calculateVersion() // Embed git hash into version
       released = new Date()
     }
   }


### PR DESCRIPTION
## PR Description
When publishing to bintray, set the version to have the git hash instead of `-SNAPSHOT` so every commit gets a unique version on bintray.  Will save us having to do a release of discovery every time we want to pull changes into Teku, but still means Teku has a deterministic version of discovery it depends on.