### PR TITLE
Require multiple confirmations before updating external address

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message.handler;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
+
+public class ExternalAddressSelector {
+
+  static final int MIN_CONFIRMATIONS = 5;
+  static final int MAX_EXTERNAL_ADDRESS_COUNT = 50;
+
+  /**
+   * Tracks an estimate of the number of nodes that have reported a particular external address. The
+   * number of addresses we keep counts for is limited to avoid peers filling our memory by
+   * reporting a large number of different address.
+   *
+   * <p>The count must never be greater than the number of unique nodes that have reported that
+   * address.
+   */
+  private final Map<InetSocketAddress, Integer> reportedAddressCounts = new HashMap<>();
+
+  private final LocalNodeRecordStore localNodeRecordStore;
+
+  public ExternalAddressSelector(final LocalNodeRecordStore localNodeRecordStore) {
+    this.localNodeRecordStore = localNodeRecordStore;
+  }
+
+  public void onExternalAddressReport(
+      final Optional<InetSocketAddress> previouslyReportedAddress,
+      final InetSocketAddress reportedAddress) {
+
+    previouslyReportedAddress.ifPresent(this::removeVote);
+    addVote(reportedAddress);
+
+    limitTrackedAddresses();
+
+    selectExternalAddress()
+        .ifPresent(
+            selectedAddress -> {
+              final Optional<InetSocketAddress> currentAddress =
+                  localNodeRecordStore.getLocalNodeRecord().getUdpAddress();
+              if (currentAddress.map(current -> !current.equals(selectedAddress)).orElse(true)) {
+                localNodeRecordStore.onSocketAddressChanged(selectedAddress);
+              }
+            });
+  }
+
+  private void limitTrackedAddresses() {
+    while (reportedAddressCounts.size() > MAX_EXTERNAL_ADDRESS_COUNT) {
+      // Too many addresses being tracked, remove the one with the fewest votes
+      reportedAddressCounts.entrySet().stream()
+          .min(Entry.comparingByValue())
+          .map(Entry::getKey)
+          .ifPresent(reportedAddressCounts::remove);
+    }
+  }
+
+  private void addVote(final InetSocketAddress reportedAddress) {
+    reportedAddressCounts.compute(
+        reportedAddress, (key, currentValue) -> currentValue != null ? currentValue + 1 : 1);
+  }
+
+  private void removeVote(final InetSocketAddress previousAddress) {
+    reportedAddressCounts.compute(
+        previousAddress,
+        (key, currentValue) -> {
+          if (currentValue == null || currentValue <= 1) {
+            // If the value has been pruned or would wind up as 0 just remove it
+            return null;
+          }
+          return currentValue - 1;
+        });
+  }
+
+  private Optional<InetSocketAddress> selectExternalAddress() {
+    return reportedAddressCounts.entrySet().stream()
+        .filter(entry -> entry.getValue() >= MIN_CONFIRMATIONS)
+        .max(Entry.comparingByValue())
+        .map(Entry::getKey);
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
@@ -4,17 +4,26 @@
 
 package org.ethereum.beacon.discovery.message.handler;
 
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
 import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 
 public class ExternalAddressSelector {
 
-  static final int MIN_CONFIRMATIONS = 5;
+  static final int MIN_CONFIRMATIONS = 2;
   static final int MAX_EXTERNAL_ADDRESS_COUNT = 50;
+  static final Duration TTL = Duration.ofMinutes(5);
 
   /**
    * Tracks an estimate of the number of nodes that have reported a particular external address. The
@@ -23,8 +32,11 @@ public class ExternalAddressSelector {
    *
    * <p>The count must never be greater than the number of unique nodes that have reported that
    * address.
+   *
+   * <p>Also tracks the last time an address is reported so that stale addresses can be removed even
+   * if they have accumlated a lot of reports.
    */
-  private final Map<InetSocketAddress, Integer> reportedAddressCounts = new HashMap<>();
+  private final Map<InetSocketAddress, ReportData> reportedAddressCounts = new HashMap<>();
 
   private final LocalNodeRecordStore localNodeRecordStore;
 
@@ -34,11 +46,13 @@ public class ExternalAddressSelector {
 
   public void onExternalAddressReport(
       final Optional<InetSocketAddress> previouslyReportedAddress,
-      final InetSocketAddress reportedAddress) {
+      final InetSocketAddress reportedAddress,
+      final Instant reportedTime) {
 
     previouslyReportedAddress.ifPresent(this::removeVote);
-    addVote(reportedAddress);
+    addVote(reportedAddress, reportedTime);
 
+    removeStaleAddresses(reportedTime);
     limitTrackedAddresses();
 
     selectExternalAddress()
@@ -52,37 +66,88 @@ public class ExternalAddressSelector {
             });
   }
 
+  private void removeStaleAddresses(final Instant now) {
+    final Instant cutOffTime = now.minus(TTL);
+    final List<InetSocketAddress> staleAddresses =
+        reportedAddressCounts.entrySet().stream()
+            .filter(entry -> entry.getValue().lastReportedBefore(cutOffTime))
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
+    staleAddresses.forEach(reportedAddressCounts::remove);
+  }
+
   private void limitTrackedAddresses() {
     while (reportedAddressCounts.size() > MAX_EXTERNAL_ADDRESS_COUNT) {
       // Too many addresses being tracked, remove the one with the fewest votes
       reportedAddressCounts.entrySet().stream()
-          .min(Entry.comparingByValue())
+          .min(Entry.comparingByValue(Comparator.comparing(ReportData::getLastReportedTime)))
           .map(Entry::getKey)
           .ifPresent(reportedAddressCounts::remove);
     }
   }
 
-  private void addVote(final InetSocketAddress reportedAddress) {
+  private void addVote(final InetSocketAddress reportedAddress, final Instant reportTime) {
     reportedAddressCounts.compute(
-        reportedAddress, (key, currentValue) -> currentValue != null ? currentValue + 1 : 1);
+        reportedAddress,
+        (key, currentValue) ->
+            currentValue != null ? currentValue.addReport(reportTime) : new ReportData(reportTime));
   }
 
   private void removeVote(final InetSocketAddress previousAddress) {
     reportedAddressCounts.compute(
         previousAddress,
-        (key, currentValue) -> {
-          if (currentValue == null || currentValue <= 1) {
-            // If the value has been pruned or would wind up as 0 just remove it
-            return null;
-          }
-          return currentValue - 1;
-        });
+        (key, currentValue) -> currentValue != null ? currentValue.removeReport() : null);
   }
 
   private Optional<InetSocketAddress> selectExternalAddress() {
     return reportedAddressCounts.entrySet().stream()
-        .filter(entry -> entry.getValue() >= MIN_CONFIRMATIONS)
-        .max(Entry.comparingByValue())
+        .filter(entry -> entry.getValue().getReportCount() >= MIN_CONFIRMATIONS)
+        .max(Entry.comparingByValue(Comparator.comparing(ReportData::getReportCount)))
         .map(Entry::getKey);
+  }
+
+  @VisibleForTesting
+  void assertInvariants() {
+    checkState(
+        reportedAddressCounts.size() <= MAX_EXTERNAL_ADDRESS_COUNT,
+        "Should limit number of tracked addresses. Size %s",
+        reportedAddressCounts.size());
+    checkState(
+        reportedAddressCounts.values().stream().noneMatch(data -> data.getReportCount() <= 0),
+        "Should not have counts less than 1 (%s)",
+        reportedAddressCounts);
+  }
+
+  private static class ReportData {
+    private int reportCount;
+    private Instant lastReportedTime;
+
+    public ReportData(final Instant time) {
+      this.reportCount = 1;
+      this.lastReportedTime = time;
+    }
+
+    public ReportData addReport(final Instant time) {
+      lastReportedTime = time;
+      reportCount++;
+      return this;
+    }
+
+    public ReportData removeReport() {
+      reportCount--;
+      return reportCount > 0 ? this : null;
+    }
+
+    public Instant getLastReportedTime() {
+      return lastReportedTime;
+    }
+
+    public int getReportCount() {
+      return reportCount;
+    }
+
+    public boolean lastReportedBefore(final Instant cutOffTime) {
+      return lastReportedTime.isBefore(cutOffTime);
+    }
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/PongHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/PongHandler.java
@@ -7,6 +7,7 @@ package org.ethereum.beacon.discovery.message.handler;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.time.Instant;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +34,8 @@ public class PongHandler implements MessageHandler<PongMessage> {
                 InetAddress.getByAddress(message.getRecipientIp().toArrayUnsafe()),
                 message.getRecipientPort());
         session.setReportedExternalAddress(reportedAddress);
-        externalAddressSelector.onExternalAddressReport(currentAddress, reportedAddress);
+        externalAddressSelector.onExternalAddressReport(
+            currentAddress, reportedAddress, Instant.now());
       } catch (UnknownHostException e) {
         logger.trace("Failed to update local node record because recipient IP was invalid", e);
       }

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/PongHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/PongHandler.java
@@ -12,29 +12,28 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.message.PongMessage;
-import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeSession;
-import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 import org.ethereum.beacon.discovery.task.TaskType;
 
 public class PongHandler implements MessageHandler<PongMessage> {
   private static final Logger logger = LogManager.getLogger();
-  private final LocalNodeRecordStore localNodeRecordStore;
+  private final ExternalAddressSelector externalAddressSelector;
 
-  public PongHandler(final LocalNodeRecordStore localNodeRecordStore) {
-    this.localNodeRecordStore = localNodeRecordStore;
+  public PongHandler(final ExternalAddressSelector externalAddressSelector) {
+    this.externalAddressSelector = externalAddressSelector;
   }
 
   @Override
   public void handle(PongMessage message, NodeSession session) {
-    final NodeRecord currentNodeRecord = localNodeRecordStore.getLocalNodeRecord();
-    final Optional<InetSocketAddress> currentAddress = currentNodeRecord.getUdpAddress();
+    final Optional<InetSocketAddress> currentAddress = session.getReportedExternalAddress();
     if (currentAddress.isEmpty() || addressDiffers(message, currentAddress.orElseThrow())) {
       try {
-        localNodeRecordStore.onSocketAddressChanged(
+        final InetSocketAddress reportedAddress =
             new InetSocketAddress(
                 InetAddress.getByAddress(message.getRecipientIp().toArrayUnsafe()),
-                message.getRecipientPort()));
+                message.getRecipientPort());
+        session.setReportedExternalAddress(reportedAddress);
+        externalAddressSelector.onExternalAddressReport(currentAddress, reportedAddress);
       } catch (UnknownHostException e) {
         logger.trace("Failed to update local node record because recipient IP was invalid", e);
       }

--- a/src/main/java/org/ethereum/beacon/discovery/processor/DiscoveryV5MessageProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/processor/DiscoveryV5MessageProcessor.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.message.DiscoveryV5Message;
 import org.ethereum.beacon.discovery.message.MessageCode;
+import org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector;
 import org.ethereum.beacon.discovery.message.handler.FindNodeHandler;
 import org.ethereum.beacon.discovery.message.handler.MessageHandler;
 import org.ethereum.beacon.discovery.message.handler.NodesHandler;
@@ -35,7 +36,8 @@ public class DiscoveryV5MessageProcessor implements DiscoveryMessageProcessor<Di
   public DiscoveryV5MessageProcessor(
       NodeRecordFactory nodeRecordFactory, final LocalNodeRecordStore localNodeRecordStore) {
     messageHandlers.put(MessageCode.PING, new PingHandler());
-    messageHandlers.put(MessageCode.PONG, new PongHandler(localNodeRecordStore));
+    messageHandlers.put(
+        MessageCode.PONG, new PongHandler(new ExternalAddressSelector(localNodeRecordStore)));
     messageHandlers.put(MessageCode.FINDNODE, new FindNodeHandler());
     messageHandlers.put(MessageCode.NODES, new NodesHandler());
     this.nodeRecordFactory = nodeRecordFactory;

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -60,6 +60,7 @@ public class NodeSession {
   private final Map<Bytes, RequestInfo> requestIdStatuses = new ConcurrentHashMap<>();
   private final ExpirationScheduler<Bytes> requestExpirationScheduler;
   private final Bytes staticNodeKey;
+  private Optional<InetSocketAddress> reportedExternalAddress = Optional.empty();
 
   public NodeSession(
       Bytes nodeId,
@@ -247,6 +248,14 @@ public class NodeSession {
 
   public void setRecipientKey(Bytes recipientKey) {
     this.recipientKey = recipientKey;
+  }
+
+  public Optional<InetSocketAddress> getReportedExternalAddress() {
+    return reportedExternalAddress;
+  }
+
+  public void setReportedExternalAddress(final InetSocketAddress reportedExternalAddress) {
+    this.reportedExternalAddress = Optional.of(reportedExternalAddress);
   }
 
   public synchronized void clearRequestId(Bytes requestId, TaskType taskType) {

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -152,12 +152,21 @@ public class DiscoveryIntegrationTest {
 
   @Test
   public void shouldUpdateLocalNodeRecord() throws Exception {
-    final DiscoverySystem node1 = createDiscoveryClient();
-    final DiscoverySystem node2 = createDiscoveryClient("0.0.0.0", node1.getLocalNodeRecord());
+    final NodeRecord[] remoteNodeRecords = {
+      createDiscoveryClient().getLocalNodeRecord(),
+      createDiscoveryClient().getLocalNodeRecord(),
+      createDiscoveryClient().getLocalNodeRecord(),
+      createDiscoveryClient().getLocalNodeRecord(),
+      createDiscoveryClient().getLocalNodeRecord()
+    };
+
+    final DiscoverySystem node2 = createDiscoveryClient("0.0.0.0", remoteNodeRecords);
 
     assertThat(node2.getLocalNodeRecord().getUdpAddress().orElseThrow().getAddress())
         .isEqualTo(InetAddress.getByName("0.0.0.0"));
-    waitFor(node2.ping(node1.getLocalNodeRecord()));
+    for (NodeRecord remoteNodeRecord : remoteNodeRecords) {
+      waitFor(node2.ping(remoteNodeRecord));
+    }
 
     // Address should have been updated. Most likely to 127.0.0.1 but it might be something else
     // if the system is configured unusually or uses IPv6 in preference to v4.

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
@@ -5,13 +5,16 @@
 package org.ethereum.beacon.discovery.message.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector.MIN_CONFIRMATIONS;
 
 import java.net.InetSocketAddress;
+import java.time.Instant;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ExternalAddressSelectorTest {
@@ -19,6 +22,7 @@ class ExternalAddressSelectorTest {
   private static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 2000);
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 2002);
   private static final InetSocketAddress ADDRESS3 = new InetSocketAddress("127.0.0.3", 2003);
+  private static final Instant START_TIME = Instant.ofEpochSecond(1_000_000);
   private final Bytes nodeId = Bytes.fromHexString("0x1234567890");
   private final NodeRecord originalNodeRecord =
       SimpleIdentitySchemaInterpreter.createNodeRecord(nodeId, ADDRESS1);
@@ -28,43 +32,48 @@ class ExternalAddressSelectorTest {
   private final ExternalAddressSelector selector =
       new ExternalAddressSelector(localNodeRecordStore);
 
+  @AfterEach
+  void tearDown() {
+    selector.assertInvariants();
+  }
+
   @Test
   void shouldNotChangeAddressUntilMinConfirmationsReached() {
-    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS - 1; i++) {
-      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    for (int i = 0; i < MIN_CONFIRMATIONS - 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
       assertSelectedAddress(ADDRESS1);
     }
-    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
     assertSelectedAddress(ADDRESS2);
   }
 
   @Test
   void shouldSelectMostVotedForAddress() {
-    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS; i++) {
-      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    for (int i = 0; i < MIN_CONFIRMATIONS; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
     }
-    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS + 1; i++) {
-      selector.onExternalAddressReport(Optional.empty(), ADDRESS3);
+    for (int i = 0; i < MIN_CONFIRMATIONS + 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS3, START_TIME);
     }
     assertSelectedAddress(ADDRESS3);
   }
 
   @Test
   void shouldReduceCountWhenNodeChangesReportedAddress() {
-    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS - 1; i++) {
-      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    for (int i = 0; i < MIN_CONFIRMATIONS - 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
       assertSelectedAddress(ADDRESS1);
     }
 
     // On the edge of switching to ADDRESS2 but now one of the peers changes its report
-    selector.onExternalAddressReport(Optional.of(ADDRESS2), ADDRESS3);
+    selector.onExternalAddressReport(Optional.of(ADDRESS2), ADDRESS3, START_TIME);
     assertSelectedAddress(ADDRESS1);
 
     // So it takes two more reports for ADDRESS2 to tick over
-    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
     assertSelectedAddress(ADDRESS1);
 
-    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
     assertSelectedAddress(ADDRESS2);
   }
 
@@ -72,10 +81,10 @@ class ExternalAddressSelectorTest {
   void shouldNotReduceCountBelowZero() {
     // Got a node that switched away from ADDRESS2 when it wasn't previously voting for it
     // Can happen because of limiting the number of reported addresses
-    selector.onExternalAddressReport(Optional.of(ADDRESS2), ADDRESS1);
+    selector.onExternalAddressReport(Optional.of(ADDRESS2), ADDRESS1, START_TIME);
     // Still only need MIN_CONFIRMATIONS to switch to ADDRESS2
-    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS; i++) {
-      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    for (int i = 0; i < MIN_CONFIRMATIONS; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
     }
     assertSelectedAddress(ADDRESS2);
   }
@@ -83,19 +92,43 @@ class ExternalAddressSelectorTest {
   @Test
   void shouldLimitNumberOfTrackedAddresses() {
     // Address 2 needs one more vote to be selected
-    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS - 1; i++) {
-      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    for (int i = 0; i < MIN_CONFIRMATIONS - 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
       assertSelectedAddress(ADDRESS1);
     }
 
     // Report a lot of different address to overflow the cache
     for (int i = 0; i < ExternalAddressSelector.MAX_EXTERNAL_ADDRESS_COUNT; i++) {
-      selector.onExternalAddressReport(Optional.empty(), new InetSocketAddress(3000 + i));
+      selector.onExternalAddressReport(
+          Optional.empty(), new InetSocketAddress(3000 + i), START_TIME);
     }
 
     // Only the least reported address should be removed so ADDRESS2 still only needs one more vote
-    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
     assertSelectedAddress(ADDRESS2);
+  }
+
+  @Test
+  void shouldRemoveStaleAddresses() {
+    // Address 2 is in use for a while and racks up a lot of reports
+    for (int i = 0; i < MIN_CONFIRMATIONS * 3; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2, START_TIME);
+    }
+    assertSelectedAddress(ADDRESS2);
+
+    // But then the external IP switches to Address 3 and we start getting reports
+    for (int i = 0; i < MIN_CONFIRMATIONS; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS3, START_TIME.plusMillis(10));
+    }
+    // But Address 2 still has more reports so we stick with it.
+    assertSelectedAddress(ADDRESS2);
+
+    // Then time passes and we drop Address 2 and use Address 3 instead
+    selector.onExternalAddressReport(
+        Optional.empty(),
+        new InetSocketAddress("127.0.0.6", 2004),
+        START_TIME.plus(ExternalAddressSelector.TTL).plusMillis(1));
+    assertSelectedAddress(ADDRESS3);
   }
 
   private void assertSelectedAddress(final InetSocketAddress address2) {

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
+import org.junit.jupiter.api.Test;
+
+class ExternalAddressSelectorTest {
+
+  private static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 2000);
+  private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 2002);
+  private static final InetSocketAddress ADDRESS3 = new InetSocketAddress("127.0.0.3", 2003);
+  private final Bytes nodeId = Bytes.fromHexString("0x1234567890");
+  private final NodeRecord originalNodeRecord =
+      SimpleIdentitySchemaInterpreter.createNodeRecord(nodeId, ADDRESS1);
+  private final LocalNodeRecordStore localNodeRecordStore =
+      new LocalNodeRecordStore(originalNodeRecord, nodeId);
+
+  private final ExternalAddressSelector selector =
+      new ExternalAddressSelector(localNodeRecordStore);
+
+  @Test
+  void shouldNotChangeAddressUntilMinConfirmationsReached() {
+    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS - 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+      assertSelectedAddress(ADDRESS1);
+    }
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    assertSelectedAddress(ADDRESS2);
+  }
+
+  @Test
+  void shouldSelectMostVotedForAddress() {
+    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    }
+    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS + 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS3);
+    }
+    assertSelectedAddress(ADDRESS3);
+  }
+
+  @Test
+  void shouldReduceCountWhenNodeChangesReportedAddress() {
+    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS - 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+      assertSelectedAddress(ADDRESS1);
+    }
+
+    // On the edge of switching to ADDRESS2 but now one of the peers changes its report
+    selector.onExternalAddressReport(Optional.of(ADDRESS2), ADDRESS3);
+    assertSelectedAddress(ADDRESS1);
+
+    // So it takes two more reports for ADDRESS2 to tick over
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    assertSelectedAddress(ADDRESS1);
+
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    assertSelectedAddress(ADDRESS2);
+  }
+
+  @Test
+  void shouldNotReduceCountBelowZero() {
+    // Got a node that switched away from ADDRESS2 when it wasn't previously voting for it
+    // Can happen because of limiting the number of reported addresses
+    selector.onExternalAddressReport(Optional.of(ADDRESS2), ADDRESS1);
+    // Still only need MIN_CONFIRMATIONS to switch to ADDRESS2
+    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    }
+    assertSelectedAddress(ADDRESS2);
+  }
+
+  @Test
+  void shouldLimitNumberOfTrackedAddresses() {
+    // Address 2 needs one more vote to be selected
+    for (int i = 0; i < ExternalAddressSelector.MIN_CONFIRMATIONS - 1; i++) {
+      selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+      assertSelectedAddress(ADDRESS1);
+    }
+
+    // Report a lot of different address to overflow the cache
+    for (int i = 0; i < ExternalAddressSelector.MAX_EXTERNAL_ADDRESS_COUNT; i++) {
+      selector.onExternalAddressReport(Optional.empty(), new InetSocketAddress(3000 + i));
+    }
+
+    // Only the least reported address should be removed so ADDRESS2 still only needs one more vote
+    selector.onExternalAddressReport(Optional.empty(), ADDRESS2);
+    assertSelectedAddress(ADDRESS2);
+  }
+
+  private void assertSelectedAddress(final InetSocketAddress address2) {
+    assertThat(localNodeRecordStore.getLocalNodeRecord().getUdpAddress()).contains(address2);
+  }
+}


### PR DESCRIPTION
## PR Description
Require multiple peers to confirm the same external address before the local node record is updated to include it. Select the most voted for external address if there are multiple ones to choose from.

## Fixed Issue(s)
https://github.com/PegaSysEng/teku/issues/1912