### PR TITLE
hash cache(homeNodeId)

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/packet/UnknownPacket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/packet/UnknownPacket.java
@@ -7,7 +7,6 @@ package org.ethereum.beacon.discovery.packet;
 import com.google.common.base.Preconditions;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
-import org.ethereum.beacon.discovery.type.Hashes;
 
 /** Default packet form until its goal is known */
 public class UnknownPacket extends AbstractPacket {
@@ -47,7 +46,7 @@ public class UnknownPacket extends AbstractPacket {
   // The recipient can recover the sender's ID by performing the same calculation in reverse.
   //
   // src-node-id      = xor(sha256(dest-node-id), tag)
-  public Optional<Bytes> getSourceNodeId(Bytes destNodeId) {
+  public Optional<Bytes> getSourceNodeId(Bytes destNodeId, Bytes destNodeIdHash) {
     Preconditions.checkArgument(!isWhoAreYouPacket(destNodeId));
 
     final Bytes bytes = getBytes();
@@ -55,7 +54,7 @@ public class UnknownPacket extends AbstractPacket {
       return Optional.empty();
     }
     Bytes xorTag = bytes.slice(0, START_MAGIC_LENGTH);
-    return Optional.of(Hashes.sha256(destNodeId).xor(xorTag));
+    return Optional.of(destNodeIdHash.xor(xorTag));
   }
 
   public void verify() {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
@@ -12,6 +12,7 @@ import org.ethereum.beacon.discovery.pipeline.Envelope;
 import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
+import org.ethereum.beacon.discovery.type.Hashes;
 
 /**
  * Assuming we have some unknown packet in {@link Field#PACKET_UNKNOWN}, resolves sender node id
@@ -21,9 +22,11 @@ import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 public class UnknownPacketTagToSender implements EnvelopeHandler {
   private static final Logger logger = LogManager.getLogger(UnknownPacketTagToSender.class);
   private final Bytes homeNodeId;
+  private final Bytes homeNodeIdHash;
 
   public UnknownPacketTagToSender(final Bytes nodeId) {
     this.homeNodeId = nodeId;
+    this.homeNodeIdHash = Hashes.sha256(nodeId);
   }
 
   @Override
@@ -46,7 +49,7 @@ public class UnknownPacketTagToSender implements EnvelopeHandler {
       return;
     }
     ((UnknownPacket) envelope.get(Field.PACKET_UNKNOWN))
-        .getSourceNodeId(homeNodeId)
+        .getSourceNodeId(homeNodeId, homeNodeIdHash)
         .ifPresentOrElse(
             fromNodeId -> envelope.put(Field.SESSION_LOOKUP, new SessionLookup(fromNodeId)),
             () -> {

--- a/src/test/java/org/ethereum/beacon/discovery/packet/UnknownPacketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/packet/UnknownPacketTest.java
@@ -16,7 +16,8 @@ class UnknownPacketTest {
   void getSourceNodeId_shouldReturnEmptyWhenPacketIsTooShort() {
     final UnknownPacket unknownPacket = new UnknownPacket(Bytes.of(1, 2, 3));
     final Bytes32 destNodeId = Bytes32.ZERO;
-    assertThat(unknownPacket.getSourceNodeId(destNodeId)).isEmpty();
+    final Bytes destNodeIdHash = Hashes.sha256(destNodeId);
+    assertThat(unknownPacket.getSourceNodeId(destNodeId, destNodeIdHash)).isEmpty();
   }
 
   @Test
@@ -24,9 +25,11 @@ class UnknownPacketTest {
     final Bytes messageData = Bytes.wrap(new byte[64]);
     final UnknownPacket unknownPacket = new UnknownPacket(messageData);
     final Bytes32 destNodeId = Bytes32.ZERO;
+    final Bytes destNodeIdHash = Hashes.sha256(destNodeId);
 
     // Should only use first 32 bytes of message data
-    final Bytes expectedSourceId = Hashes.sha256(destNodeId).xor(messageData.slice(0, 32));
-    assertThat(unknownPacket.getSourceNodeId(destNodeId)).contains(expectedSourceId);
+    final Bytes expectedSourceId = destNodeIdHash.xor(messageData.slice(0, 32));
+    assertThat(unknownPacket.getSourceNodeId(destNodeId, destNodeIdHash))
+        .contains(expectedSourceId);
   }
 }


### PR DESCRIPTION
## PR Description
caching the hash(homeNodeId) so it doesn't have to be recalculated each time a tag is decoded on a RandomPacket
## Fixed Issue(s)
resolves #66 
